### PR TITLE
Issue #7: Fixed text alignment when rendering point display

### DIFF
--- a/Source/Page_PrepareCarefully.cs
+++ b/Source/Page_PrepareCarefully.cs
@@ -80,11 +80,12 @@ namespace EdB.PrepareCarefully
 			TipSignal tip = new TipSignal(() => tooltipText, tooltipText.GetHashCode());
 			TooltipHandler.TipRegion(rect, tip);
 
-			// Removed points.
-			/*
 			GUI.color = ColorText;
 			Text.Anchor = TextAnchor.UpperLeft;
 			Text.Font = GameFont.Small;
+		
+			// Removed points.
+			/*
 			string optionLabel;
 			float optionTop = parentRect.height - 97;
 			optionLabel = "EdB.PrepareCarefully.UsePoints".Translate();


### PR DESCRIPTION
Fix for issue #7.   Uncommented the lines that reset the text alignment in `Page_PrepareCarefully`