### PR TITLE
Issue #6: Added call to reset textures when mods are reloaded

### DIFF
--- a/Source/ModController.cs
+++ b/Source/ModController.cs
@@ -129,7 +129,7 @@ namespace EdB.PrepareCarefully
 
 		public void ResetTextures()
 		{
-
+			Textures.Reset();
 		}
 
 		public bool ModEnabled


### PR DESCRIPTION
Fix for issue #6.  When mods are reloaded after making changes on the mod screen, textures need to be explicitly reloaded in the mod controller.