### PR TITLE
Issue #17: Fixed backstory pre-selection when clicking on the adult backstory name

### DIFF
--- a/Source/Page_ConfigureStartingPawnsCarefully.cs
+++ b/Source/Page_ConfigureStartingPawnsCarefully.cs
@@ -1794,7 +1794,7 @@ namespace EdB.PrepareCarefully
 
 		protected void ShowBackstoryDialog(CustomPawn customPawn, BackstorySlot slot)
 		{
-			Backstory originalBackstory = customPawn.Childhood;
+			Backstory originalBackstory = (slot == BackstorySlot.Childhood) ? customPawn.Childhood : customPawn.Adulthood;
 			Backstory selectedBackstory = originalBackstory;
 			Dialog_Options<Backstory> dialog = new Dialog_Options<Backstory>(slot == BackstorySlot.Childhood ? this.sortedChildhoodBackstories : this.sortedAdulthoodBackstories) {
 				NameFunc = (Backstory backstory) => {


### PR DESCRIPTION
Fix for issue #17.