### PR TITLE
Issue #4: Fixes to support scenario forced hediffs

### DIFF
--- a/Resources/Languages/English/Keyed/EdBPrepareCarefully.xml
+++ b/Resources/Languages/English/Keyed/EdBPrepareCarefully.xml
@@ -103,7 +103,7 @@
 	<EdB.PrepareCarefully.Close>Close</EdB.PrepareCarefully.Close>
 	<EdB.PrepareCarefully.CannotDeleteRelationship>This relationship cannot be deleted because it was automatically added due to another relationship.  Delete the original relationship to remove this one as well.</EdB.PrepareCarefully.CannotDeleteRelationship>
 	<EdB.PrepareCarefully.RandomizeInjuries>Random Injuries</EdB.PrepareCarefully.RandomizeInjuries>
-	<EdB.PrepareCarefully.RandomizeInjuries.Tooltip>You must remove all injuries from the colonist to enable random injury generation.  Injuries will be determined based on the colonist's age.</EdB.PrepareCarefully.RandomizeInjuries.Tooltip>
+	<EdB.PrepareCarefully.RandomizeInjuries.Tooltip>You must remove all conditions from the colonist to enable random injury generation.  Injuries will be determined based on the colonist's age.</EdB.PrepareCarefully.RandomizeInjuries.Tooltip>
 	<EdB.PrepareCarefully.AddImplant>Add Implant...</EdB.PrepareCarefully.AddImplant>
 	<EdB.PrepareCarefully.SelectImplant>Select an Implant Procedure</EdB.PrepareCarefully.SelectImplant>
 	<EdB.PrepareCarefully.ErrorMustSelectImplant>You must select an implant procedure</EdB.PrepareCarefully.ErrorMustSelectImplant>
@@ -111,9 +111,9 @@
 	<EdB.PrepareCarefully.ErrorMustSelectBodyPart>You must select a location</EdB.PrepareCarefully.ErrorMustSelectBodyPart>
 	<EdB.PrepareCarefully.SelectSeverity>Select a severity level</EdB.PrepareCarefully.SelectSeverity>
 	<EdB.PrepareCarefully.ErrorMustSelectSelectSeverity>You must select a severity level</EdB.PrepareCarefully.ErrorMustSelectSelectSeverity>
-	<EdB.PrepareCarefully.AddInjury>Add Injury...</EdB.PrepareCarefully.AddInjury>
-	<EdB.PrepareCarefully.SelectInjury>Select an Injury</EdB.PrepareCarefully.SelectInjury>
-	<EdB.PrepareCarefully.ErrorMustSelectInjury>You must select an injury</EdB.PrepareCarefully.ErrorMustSelectInjury>
+	<EdB.PrepareCarefully.AddInjury>Add Condition...</EdB.PrepareCarefully.AddInjury>
+	<EdB.PrepareCarefully.SelectInjury>Select a condition</EdB.PrepareCarefully.SelectInjury>
+	<EdB.PrepareCarefully.ErrorMustSelectInjury>You must select a condition</EdB.PrepareCarefully.ErrorMustSelectInjury>
 	<EdB.PrepareCarefully.InjuryLabel>{0} ({1})</EdB.PrepareCarefully.InjuryLabel>
 	<EdB.PrepareCarefully.EquipmentTab.Implants>Implants</EdB.PrepareCarefully.EquipmentTab.Implants>
 	<EdB.PrepareCarefully.EquipmentTab.Buildings>Furniture</EdB.PrepareCarefully.EquipmentTab.Buildings>
@@ -128,5 +128,8 @@
 	<EdB.PrepareCarefully.PresetVersionNotSupported>Pre-alpha 13 versions of presets are not supported.</EdB.PrepareCarefully.PresetVersionNotSupported>
 	<EdB.PrepareCarefully.SavedColonistVersionNotSupported>Pre-alpha 13 versions of saved colonists are not supported.</EdB.PrepareCarefully.SavedColonistVersionNotSupported>
 	<EdB.PrepareCarefully.CostSummary.Implants>Implants: {0}</EdB.PrepareCarefully.CostSummary.Implants>
+
+	<!-- New for Alpha 14 -->
+	<EdB.PrepareCarefully.WholeBody>Whole Body</EdB.PrepareCarefully.WholeBody>
 
 </LanguageData>

--- a/Source/CustomBodyPart.cs
+++ b/Source/CustomBodyPart.cs
@@ -15,7 +15,7 @@ namespace EdB.PrepareCarefully
 
 		public virtual string PartName {
 			get {
-				return BodyPartRecord != null ? BodyPartRecord.def.LabelCap : "No part!"; 
+				return BodyPartRecord != null ? BodyPartRecord.def.LabelCap : "EdB.PrepareCarefully.WholeBody".Translate(); 
 			}
 		}
 

--- a/Source/Injury.cs
+++ b/Source/Injury.cs
@@ -90,12 +90,23 @@ namespace EdB.PrepareCarefully
 				this.hediff = hediff;
 			}
 			else if (Option.IsOldInjury) {
-				Hediff_Injury hediff = (Hediff_Injury) HediffMaker.MakeHediff(Option.HediffDef, pawn, null);
+				Hediff hediff = HediffMaker.MakeHediff(Option.HediffDef, pawn, null);
 				hediff.Severity = this.Severity;
-				hediff.TryGetComp<HediffComp_GetsOld>().IsOld = true;
-				// TODO: This should not be hard-coded.
-				hediff.TryGetComp<HediffComp_GetsOld>().painFactor = 4;
+
+				HediffComp_GetsOld getsOld = hediff.TryGetComp<HediffComp_GetsOld>();
+				if (getsOld != null) {
+					hediff.TryGetComp<HediffComp_GetsOld>().IsOld = true;
+					// TODO: Pain factor should not be hard-coded.
+					hediff.TryGetComp<HediffComp_GetsOld>().painFactor = 4;
+				}
+
 				pawn.health.AddHediff(hediff, BodyPartRecord, null);
+				this.hediff = hediff;
+			}
+			else {
+				Hediff hediff = HediffMaker.MakeHediff(Option.HediffDef, pawn, null);
+				hediff.Severity = this.Severity;
+				pawn.health.AddHediff(hediff, null, null);
 				this.hediff = hediff;
 			}
 			pawn.health.capacities.Clear();

--- a/Source/Panel_Health.cs
+++ b/Source/Panel_Health.cs
@@ -149,20 +149,31 @@ namespace EdB.PrepareCarefully
 						customPawn.AddInjury(injury);
 					}
 					else {
-						foreach (var p in selectedInjury.ValidParts) {
-							BodyPartRecord record = PrepareCarefully.Instance.HealthManager.FirstBodyPartRecord(p);
-							if (record != null) {
-								Injury injury= new Injury();
-								injury.BodyPartRecord = record;
-								injury.Option = selectedInjury;
-								if (selectedSeverity != null) {
-									injury.Severity = selectedSeverity.Value;
+						if (selectedInjury.ValidParts.Count > 0) {
+							foreach (var p in selectedInjury.ValidParts) {
+								BodyPartRecord record = PrepareCarefully.Instance.HealthManager.FirstBodyPartRecord(p);
+								if (record != null) {
+									Injury injury = new Injury();
+									injury.BodyPartRecord = record;
+									injury.Option = selectedInjury;
+									if (selectedSeverity != null) {
+										injury.Severity = selectedSeverity.Value;
+									}
+									customPawn.AddInjury(injury);
 								}
-								customPawn.AddInjury(injury);
+								else {
+									Log.Warning("Could not find body part record for definition: " + p.defName);
+								}
 							}
-							else {
-								Log.Warning("Could not find body part record for definition: " + p.defName);
+						}
+						else {
+							Injury injury = new Injury();
+							injury.BodyPartRecord = null;
+							injury.Option = selectedInjury;
+							if (selectedSeverity != null) {
+								injury.Severity = selectedSeverity.Value;
 							}
+							customPawn.AddInjury(injury);
 						}
 					}
 				};
@@ -243,7 +254,7 @@ namespace EdB.PrepareCarefully
 					},
 					SelectAction = (InjuryOption option) => {
 						selectedInjury = option;
-						if (option.ValidParts == null || option.ValidParts.Count == 0) {
+						if (option.ValidParts == null) {
 							bodyPartSelectionRequired = true;
 						}
 						else {


### PR DESCRIPTION
Fixes to support scenario forced hediffs (i.e. cryptosleep sickness, malnutrition, etc).
- Renamed "injury" to "condition."
- Tweaked the logic that checks to see if a part must be selected for a hediff
- Other tweaks to support hediffs added to the whole body instead to a specific part.