### PR TITLE
Issue #16: Added an alert when the prepare carefully genstep is not detected

### DIFF
--- a/Resources/Languages/English/Keyed/EdBPrepareCarefully.xml
+++ b/Resources/Languages/English/Keyed/EdBPrepareCarefully.xml
@@ -131,5 +131,11 @@
 
 	<!-- New for Alpha 14 -->
 	<EdB.PrepareCarefully.WholeBody>Whole Body</EdB.PrepareCarefully.WholeBody>
+	<EdB.PrepareCarefully.ModConfigProblem.Title>Warning</EdB.PrepareCarefully.ModConfigProblem.Title>
+	<EdB.PrepareCarefully.ModConfigProblem.Description>There is a problem with your mod configuration.
+
+Prepare Carefully is a map generation mod.  It appears that you have another mod enabled that also modifies the game's map generation and is overriding Prepare Carefully.
+
+Your colonist customizations will be ignored.</EdB.PrepareCarefully.ModConfigProblem.Description>
 
 </LanguageData>

--- a/Source/Page_ConfigureStartingPawns.cs
+++ b/Source/Page_ConfigureStartingPawns.cs
@@ -73,6 +73,10 @@ namespace EdB.PrepareCarefully
 			Action prepareCarefullyAction = () => {
 				PrepareCarefully.Instance.Initialize();
 				Find.WindowStack.Add(new Page_ConfigureStartingPawnsCarefully());
+				if (!PrepareCarefully.Instance.FindScenPart()) {
+					Find.WindowStack.Add(new Dialog_Confirm("EdB.PrepareCarefully.ModConfigProblem.Description".Translate(),
+						delegate {}, true, "EdB.PrepareCarefully.ModConfigProblem.Title".Translate(), false));
+				}
 			};
 			base.DoBottomButtons(rect, "Start".Translate(), "EdB.PrepareCarefully".Translate(), prepareCarefullyAction, true);
 		}

--- a/Source/PrepareCarefully.cs
+++ b/Source/PrepareCarefully.cs
@@ -458,7 +458,27 @@ namespace EdB.PrepareCarefully
 				facades.Add(pawnToFacadeMap[pawn]);
 			}
 			relationshipManager = new RelationshipManager(Verse.Find.GameInitData.startingPawns, facades);
-		}			
+		}
+
+		public bool FindScenPart()
+		{
+			if (DefDatabase<MapGeneratorDef>.AllDefs.Count() == 1) {
+				MapGeneratorDef def = DefDatabase<MapGeneratorDef>.AllDefs.First();
+				if (def != null) {
+					foreach (var g in def.genSteps) {
+						if (g.GetType().FullName.Equals("EdB.PrepareCarefully.Genstep_ScenParts")) {
+							return true;
+						}
+					}
+					return false;
+				}
+			}
+			// TODO: We can't figure this out in every situation.  If there's more than one
+			// map generator, the game is going to pick one at random, and we can't know at this
+			// point which one it's going to pick.  In that case, we'll assume that everything is
+			// good.
+			return true;
+		}
 	}
 }
 


### PR DESCRIPTION
Fix for issue #16.  Adding an alert when when Prepare Carefully cannot detect that its custom map generation step is available.

Cannot detect this 100% of time if additional map generators have been added (which is unlikely).