### PR TITLE
Made it more difficult to kill a colonist by applying injuries

### DIFF
--- a/Source/Dialog_Options.cs
+++ b/Source/Dialog_Options.cs
@@ -172,7 +172,7 @@ namespace EdB.PrepareCarefully
 					GUI.color = new Color(0.65f, 0.65f, 0.65f);
 					Widgets.Label(new Rect(0, cursor + 2, ContentSize.x - 32, height), name);
 					Texture2D image = Textures.TextureRadioButtonOff;
-					Vector2 topLeft = new Vector2(itemRect.x + itemRect.width - 32, itemRect.y + itemRect.height / 2 - 16);
+					Vector2 topLeft = new Vector2(itemRect.x + itemRect.width - 24, itemRect.y + itemRect.height / 2 - 12);
 					GUI.color = new Color(1, 1, 1, 0.28f);
 					GUI.DrawTexture(new Rect(topLeft.x, topLeft.y, 24, 24), image);
 					GUI.color = Color.white;

--- a/Source/InjuryManager.cs
+++ b/Source/InjuryManager.cs
@@ -167,6 +167,9 @@ namespace EdB.PrepareCarefully
 
 		public bool DoesStageKillPawn(HediffDef def, HediffStage stage)
 		{
+			if (def.lethalSeverity > -1.0f && stage.minSeverity >= def.lethalSeverity) {
+				return true;
+			}
 			if (stage.capMods != null) {
 				foreach (var c in stage.capMods) {
 					if (c.capacity == PawnCapacityDefOf.Consciousness) {


### PR DESCRIPTION
Adding enough injuries to kill a colonist throws an error, so we need to try to avoid it:
- Filtering out hediff stages that will definitely kill the colonist.
- Disabled certain injuries (non-"old injuries") in the injury dialog if you've already added them to the colonist (i.e. can no longer add malaria twice).

Also tweaked the spacing when drawing the disabled radio button texture.