### PR TITLE
Apparel enhancements

### DIFF
--- a/Resources/Languages/English/Keyed/EdBPrepareCarefully.xml
+++ b/Resources/Languages/English/Keyed/EdBPrepareCarefully.xml
@@ -137,5 +137,6 @@
 Prepare Carefully is a map generation mod.  It appears that you have another mod enabled that also modifies the game's map generation and is overriding Prepare Carefully.
 
 Your colonist customizations will be ignored.</EdB.PrepareCarefully.ModConfigProblem.Description>
-
+	<EdB.PawnLayer.Accessory>Accessory</EdB.PawnLayer.Accessory>
+	
 </LanguageData>

--- a/Source/CustomPawn.cs
+++ b/Source/CustomPawn.cs
@@ -144,8 +144,6 @@ namespace EdB.PrepareCarefully
 			colors.Add(Color.white);
 			graphics.Add(null);
 			colors.Add(Color.white);
-			graphics.Add(null);
-			colors.Add(Color.white);
 
 			graphics.Add(GraphicDatabaseHeadRecords.GetHeadNamed(pawn.story.HeadGraphicPath, pawn.story.SkinColor));
 			colors.Add(pawn.story.SkinColor);
@@ -154,6 +152,8 @@ namespace EdB.PrepareCarefully
 			graphics.Add(GraphicsCache.Instance.GetHair(pawn.story.hairDef));
 			colors.Add(pawn.story.hairColor);
 
+			graphics.Add(null);
+			colors.Add(Color.white);
 			graphics.Add(null);
 			colors.Add(Color.white);
 

--- a/Source/Page_ConfigureStartingPawnsCarefully.cs
+++ b/Source/Page_ConfigureStartingPawnsCarefully.cs
@@ -201,7 +201,7 @@ namespace EdB.PrepareCarefully
 
 			// Get all apparel options
 			foreach (ThingDef apparelDef in DefDatabase<ThingDef>.AllDefs) {
-				if (apparelDef.apparel == null || apparelDef.defName == "Apparel_PersonalShield") {
+				if (apparelDef.apparel == null) {
 					continue;
 				}
 				int layer = PawnLayers.ToPawnLayerIndex(apparelDef.apparel);

--- a/Source/Page_ConfigureStartingPawnsCarefully.cs
+++ b/Source/Page_ConfigureStartingPawnsCarefully.cs
@@ -144,6 +144,7 @@ namespace EdB.PrepareCarefully
 				PawnLayers.BottomClothingLayer,
 				PawnLayers.MiddleClothingLayer,
 				PawnLayers.TopClothingLayer,
+				PawnLayers.Accessory,
 				PawnLayers.Hat
 			});
 			pawnLayerActions = new List<Action>(new Action[] {
@@ -153,7 +154,8 @@ namespace EdB.PrepareCarefully
 				delegate { this.ChangePawnLayer(PawnLayers.BottomClothingLayer); },
 				delegate { this.ChangePawnLayer(PawnLayers.MiddleClothingLayer); },
 				delegate { this.ChangePawnLayer(PawnLayers.TopClothingLayer); },
-				delegate { this.ChangePawnLayer(PawnLayers.Hat); },
+				delegate { this.ChangePawnLayer(PawnLayers.Accessory); },
+				delegate { this.ChangePawnLayer(PawnLayers.Hat); }
 			});
 
 			// Initialize and sort hair lists.
@@ -817,6 +819,15 @@ namespace EdB.PrepareCarefully
 				List<FloatMenuOption> list = new List<FloatMenuOption>();
 				int layerCount = this.pawnLayerActions.Count;
 				for (int i = 0; i < layerCount; i++) {
+					int pawnLayer = pawnLayers[i];
+					// Only add apparel layers that have items.
+					if (PawnLayers.IsApparelLayer(pawnLayer)) {
+						if (pawnLayer == PawnLayers.Accessory) {
+							if (apparelLists[pawnLayer] == null || apparelLists[pawnLayer].Count == 0) {
+								continue;
+							}
+						}
+					}
 					label = PawnLayers.Label(pawnLayers[i]);
 					list.Add(new FloatMenuOption(label, this.pawnLayerActions[i], MenuOptionPriority.Medium, null, null, 0, null));
 				}
@@ -1268,6 +1279,7 @@ namespace EdB.PrepareCarefully
 			Rect headRect = new Rect(bodyRect.x, bodyRect.y - 30, 128, 128);
 			List<Graphic> graphics = customPawn.graphics;
 			DrawGraphics(bodyRect, PawnLayers.BodyType, PawnLayers.TopClothingLayer);
+			DrawGraphic(bodyRect, PawnLayers.Accessory);
 			DrawGraphic(headRect, PawnLayers.HeadType);
 			DrawOneGraphic(headRect, PawnLayers.Hat, PawnLayers.Hair);
 

--- a/Source/PawnLayers.cs
+++ b/Source/PawnLayers.cs
@@ -11,9 +11,10 @@ namespace EdB.PrepareCarefully
 		public const int Pants = 2;
 		public const int MiddleClothingLayer = 3;
 		public const int TopClothingLayer = 4;
-		public const int HeadType = 5;
-		public const int Hair = 6;
-		public const int Hat = 7;
+		public const int Accessory = 5;
+		public const int HeadType = 6;
+		public const int Hair = 7;
+		public const int Hat = 8;
 
 		public const int Count = Hat + 1;
 
@@ -35,6 +36,8 @@ namespace EdB.PrepareCarefully
 					return "EdB.PawnLayer.Hair".Translate();
 				case Hat:
 					return "EdB.PawnLayer.Hat".Translate();
+				case Accessory:
+					return "EdB.PawnLayer.Accessory".Translate();
 				default:
 					return "";
 			}
@@ -50,6 +53,8 @@ namespace EdB.PrepareCarefully
 					return TopClothingLayer;
 				case ApparelLayer.Overhead:
 					return Hat;
+				case ApparelLayer.Accessory:
+					return Accessory;
 				default:
 					return -1;
 			}
@@ -68,6 +73,8 @@ namespace EdB.PrepareCarefully
 						return MiddleClothingLayer;
 					case ApparelLayer.Shell:
 						return TopClothingLayer;
+					case ApparelLayer.Accessory:
+						return Accessory;
 					case ApparelLayer.Overhead:
 						return Hat;
 					default:
@@ -91,6 +98,8 @@ namespace EdB.PrepareCarefully
 					return ApparelLayer.Shell;
 				case Hat:
 					return ApparelLayer.Overhead;
+				case Accessory:
+					return ApparelLayer.Accessory;
 				default:
 					return ApparelLayer.OnSkin;
 			}
@@ -113,6 +122,8 @@ namespace EdB.PrepareCarefully
 				case Hair:
 					return false;
 				case Hat:
+					return true;
+				case Accessory:
 					return true;
 				default:
 					return false;

--- a/Source/PawnLayers.cs
+++ b/Source/PawnLayers.cs
@@ -11,12 +11,12 @@ namespace EdB.PrepareCarefully
 		public const int Pants = 2;
 		public const int MiddleClothingLayer = 3;
 		public const int TopClothingLayer = 4;
-		public const int Accessory = 5;
-		public const int HeadType = 6;
-		public const int Hair = 7;
-		public const int Hat = 8;
+		public const int HeadType = 5;
+		public const int Hair = 6;
+		public const int Hat = 7;
+		public const int Accessory = 8;
 
-		public const int Count = Hat + 1;
+		public const int Count = Accessory + 1;
 
 		public static String Label(int layer) {
 			switch (layer) {


### PR DESCRIPTION
- Added support for the Accessory layer
- Added the Personal Shield back into the apparel selections (had been explicitly removing it)
- Fixed the logic for determining apparel conflicts.  Should now allow apparel that covers the same layer but doesn't cover the same body part groups.
- Fixed the way that apparel is added to the finished pawn so that it now matches up with vanilla.  This fixes broken shield items.