### PR TITLE
Fixed ModController.ModEnabled to recognize multiple installs

### DIFF
--- a/Source/ModController.cs
+++ b/Source/ModController.cs
@@ -135,13 +135,10 @@ namespace EdB.PrepareCarefully
 		public bool ModEnabled
 		{
 			get {
-				ModMetaData mod = ModLister.AllInstalledMods.First((ModMetaData m) => {
-					return m.Name.Equals(ModName);
+				ModMetaData mod = ModLister.AllInstalledMods.FirstOrDefault((ModMetaData m) => {
+					return m.Name.Equals(ModName) && m.Active;
 				});
-				if (mod == null) {
-					return false;
-				}
-				return mod.Active;
+				return mod != null;
 			}
 		}
     }


### PR DESCRIPTION
Fix for Issue #38.  Fixed the logic in `ModController.ModEnabled` to handle the case where multiple copies of the mod are installed.