### PR TITLE
Tweaks/fixes for 0.14.2.1

### DIFF
--- a/Source/Panel_Health.cs
+++ b/Source/Panel_Health.cs
@@ -391,7 +391,6 @@ namespace EdB.PrepareCarefully
 
 		protected void ResetInjuryOptionEnabledState(CustomPawn pawn)
 		{
-			Log.Warning("ResetInjuryOptionEnabledState()");
 			disabledInjuryOptions.Clear();
 			InjuryManager injuryManager = PrepareCarefully.Instance.HealthManager.InjuryManager;
 			foreach (var injuryOption in injuryManager.Options) {
@@ -400,9 +399,6 @@ namespace EdB.PrepareCarefully
 					continue;
 				}
 				Injury injury = pawn.Injuries.FirstOrDefault((Injury i) => {
-					if (i.Option == option) {
-						Log.Warning("Pawn has the injury already: " + i.Option.HediffDef.defName);
-					}
 					return (i.Option == option);
 				});
 				if (injury != null) {

--- a/Source/Version3/PresetLoaderVersion3.cs
+++ b/Source/Version3/PresetLoaderVersion3.cs
@@ -28,7 +28,6 @@ namespace EdB.PrepareCarefully
 
 				Scribe_Values.LookValue<bool>(ref usePoints, "usePoints", true, false);
 				Scribe_Values.LookValue<int>(ref startingPoints, "startingPoints", 0, false);
-				PrepareCarefully.Instance.StartingPoints = startingPoints;
 				Scribe_Values.LookValue<string>(ref ModString, "mods", "", false);
 
 				try {


### PR DESCRIPTION
- Removed debug logging statements from health panel
- Prevented presets from resetting the point value to the value saved with the preset.  It only made sense to do this before there were scenarios.