### PR TITLE
Pawn randomizer change

### DIFF
--- a/Source/Randomizer.cs
+++ b/Source/Randomizer.cs
@@ -11,7 +11,9 @@ namespace EdB.PrepareCarefully
 		public Pawn GenerateColonist()
 		{
 			PawnKindDef kindDef = Faction.OfPlayer.def.basicMemberKind;
-			Pawn pawn = PawnGenerator.GeneratePawn(kindDef, Faction.OfPlayer);
+			Pawn pawn = PawnGenerator.GeneratePawn(new PawnGenerationRequest(kindDef, Faction.OfPlayer,
+					PawnGenerationContext.PlayerStarter, true, false, false, false, false, false, 0f, false, true,
+			        false, null, null, null, null, null, null));
 			return pawn;
 		}
 


### PR DESCRIPTION
Updated Randomizer.GenerateColonist() to explicitly use a PawnGenerationRequest with a few specific parameters in an attempt to better match the initial colonist generation.

Hopefully, by setting the pawn generation context value, we fix an issue where generated colonists were never getting assigned names from name-in-game pawns.