### PR TITLE
Fixes for Issue #77

### DIFF
--- a/Resources/Languages/English/Keyed/EdBPrepareCarefully.xml
+++ b/Resources/Languages/English/Keyed/EdBPrepareCarefully.xml
@@ -142,5 +142,10 @@ Your colonist customizations will be ignored.</EdB.PrepareCarefully.ModConfigPro
 
 	<!-- New for Alpha 15 -->
 	<EdB.PrepareCarefully.EquipmentTab.Medical>Medical</EdB.PrepareCarefully.EquipmentTab.Medical>
-	
+
+	<EdB.PrepareCarefully.UnrecoverableError.Header>Unrecoverable Error</EdB.PrepareCarefully.UnrecoverableError.Header>
+	<EdB.PrepareCarefully.UnrecoverableError.Message>Something went wrong, and Prepare Carefully was not able to recover.  The following error message may help identify the problem:
+
+"{0}"</EdB.PrepareCarefully.UnrecoverableError.Message>
+
 </LanguageData>

--- a/Source/Page_ConfigureStartingPawnsCarefully.cs
+++ b/Source/Page_ConfigureStartingPawnsCarefully.cs
@@ -400,6 +400,11 @@ namespace EdB.PrepareCarefully
 				return;
 			}
 
+			if (!Textures.Loaded) {
+				FatalError("Textures failed to load", null);
+				return;
+			}
+
 			Rect rect = new Rect(0, 80, inRect.width, inRect.height - 60 - 80);
 			Widgets.DrawMenuSection(rect, true);
 			int tabCount = PrepareCarefully.Instance.Pawns.Count;

--- a/Source/Page_PrepareCarefully.cs
+++ b/Source/Page_PrepareCarefully.cs
@@ -37,11 +37,28 @@ namespace EdB.PrepareCarefully
 		}
 			
 		protected void FatalError(string message, Exception e) {
-			Log.Error("An unrecoverable error has occurred in the Prepare Carefully mod");
-			Log.Error(message);
-			Log.Error(e.ToString());
-			Log.Error(e.StackTrace);
 			this.broken = true;
+			string displayMessage = null;
+			if (e != null) {
+				displayMessage = e.ToString();
+			}
+			if (displayMessage.NullOrEmpty()) {
+				displayMessage = message;
+			}
+			if (displayMessage.NullOrEmpty()) {
+				displayMessage = "Unknown error";
+			}
+			Find.WindowStack.Add(new Dialog_Confirm("EdB.PrepareCarefully.UnrecoverableError.Message".Translate(new object[] { displayMessage }),
+					delegate {
+						PrepareCarefully.Instance.Clear();
+						this.Close(true);
+						Log.Error("An unrecoverable error has occurred in the Prepare Carefully mod");
+						Log.Error(message);
+						if (e != null) {
+							Log.Error(e.ToString());
+							Log.Error(e.StackTrace);
+						}
+			}, false, "EdB.PrepareCarefully.UnrecoverableError.Header".Translate(), false));
 		}
 
 		protected void DrawCost(Rect parentRect)

--- a/Source/PrepareCarefully.cs
+++ b/Source/PrepareCarefully.cs
@@ -155,6 +155,7 @@ namespace EdB.PrepareCarefully
 
 		public void Initialize()
 		{
+			Textures.Reset();
 			Clear();
 			PawnColorUtils.InitializeColors();
 			InitializePawns();

--- a/Source/Textures.cs
+++ b/Source/Textures.cs
@@ -8,6 +8,8 @@ namespace EdB.PrepareCarefully
 	[StaticConstructorOnStartup]
 	public static class Textures
 	{
+		private static bool loaded = false;
+
 		public static Texture2D TexturePassionMajor;
 		public static Texture2D TexturePassionMinor;
 		public static Texture2D TextureFieldAtlas;
@@ -38,6 +40,12 @@ namespace EdB.PrepareCarefully
 			LoadTextures();
 		}
 
+		public static bool Loaded {
+			get {
+				return loaded;
+			}
+		}
+
 		public static void Reset()
 		{
 			LongEventHandler.ExecuteWhenFinished(() => {
@@ -47,6 +55,7 @@ namespace EdB.PrepareCarefully
 
 		private static void LoadTextures()
 		{
+			loaded = false;
 			TexturePassionMajor = ContentFinder<Texture2D>.Get("UI/Icons/PassionMajor", true);
 			TexturePassionMinor = ContentFinder<Texture2D>.Get("UI/Icons/PassionMinor", true);
 			TextureRadioButtonOff = ContentFinder<Texture2D>.Get("UI/Widgets/RadioButOff", true);
@@ -74,7 +83,7 @@ namespace EdB.PrepareCarefully
 			TextureAlternateRow = SolidColorMaterials.NewSolidColorTexture(new Color(1, 1, 1, 0.05f));
 			TextureSkillBarFill = SolidColorMaterials.NewSolidColorTexture(new Color(1f, 1f, 1f, 0.1f));
 
-
+			loaded = true;
 		}
 	}
 }


### PR DESCRIPTION
- Changed the way that fatal errors are handled.  We now display a popup with the exception message to make it easier for users who are not familiar with development mode or logs files to post a screenshot of a problem.
- Added fix to re-initialize the mod textures whenever the Prepare Carefully window is opened.  This handles the case where textures are reset to null whenever you switch languages or enable/disable other mods without restarting.