### PR TITLE
Better support for modded non-human pawns

### DIFF
--- a/EdBPrepareCarefully.csproj
+++ b/EdBPrepareCarefully.csproj
@@ -108,6 +108,7 @@
     <Compile Include="Source\GenStep_ScenParts.cs" />
     <Compile Include="Source\Dialog_Confirm.cs" />
     <Compile Include="Source\ThingCache.cs" />
+    <Compile Include="Source\BodyPartDictionary.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup />

--- a/Source/BodyPartDictionary.cs
+++ b/Source/BodyPartDictionary.cs
@@ -1,0 +1,184 @@
+﻿using RimWorld;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using UnityEngine;
+using Verse;
+using Verse.Sound;
+
+namespace EdB.PrepareCarefully
+{
+	public class BodyPartDictionary
+	{
+		protected Dictionary<BodyPartDef, List<BodyPartRecord>> bodyPartListLookup = new Dictionary<BodyPartDef, List<BodyPartRecord>>();
+		protected List<RecipeDef> recipes = new List<RecipeDef>();
+		protected Dictionary<RecipeDef, List<BodyPartRecord>> recipeBodyParts = new Dictionary<RecipeDef, List<BodyPartRecord>>();
+		protected HashSet<BodyPartRecord> replaceableParts = new HashSet<BodyPartRecord>();
+		protected Dictionary<BodyPartRecord, HashSet<BodyPartRecord>> bodyPartAncestors = new Dictionary<BodyPartRecord, HashSet<BodyPartRecord>>();
+		protected List<BodyPartRecord> allBodyParts = new List<BodyPartRecord>();
+		protected List<BodyPartRecord> allOutsideBodyParts = new List<BodyPartRecord>();
+		protected List<BodyPartRecord> allSkinCoveredBodyParts = new List<BodyPartRecord>();
+		private BodyDef bodyDef;
+
+		public BodyDef BodyDef {
+			get {
+				return bodyDef;
+			}
+		}
+
+		public List<RecipeDef> ImplantRecipes {
+			get {
+				return recipes;
+			}
+		}
+
+		public IEnumerable<BodyPartRecord> AllBodyParts {
+			get { return allBodyParts; }
+		}
+
+		public IEnumerable<BodyPartRecord> AllOutsideBodyParts {
+			get { return allOutsideBodyParts; }
+		}
+
+		public IEnumerable<BodyPartRecord> AllSkinCoveredBodyParts {
+			get { return allSkinCoveredBodyParts; }
+		}
+
+		public BodyPartDictionary(ThingDef pawnThingDef)
+		{
+			this.bodyDef = pawnThingDef.race.body;
+
+			// Go through all of the body part records for the race.  Each record is an individual body part, and you
+			// will see more than one instance of each record.  For example, you'll see 12 "Rib" records, one for each
+			// of the 12 rib bones.  For each body part type (i.e. "Rib"), we store a list of each body part record
+			// in a dictionary, so that we can get a list of all records that match a given type/definition.
+			foreach (BodyPartRecord record in bodyDef.AllParts) {
+				List<BodyPartRecord> records;
+				if (!bodyPartListLookup.TryGetValue(record.def, out records)) {
+					records = new List<BodyPartRecord>();
+					bodyPartListLookup[record.def] = records;
+				}
+				records.Add(record);
+				AddAncestors(record);
+			}
+
+			// Find all recipes that replace a body part.
+			recipes.AddRange(pawnThingDef.recipes.Where((RecipeDef def) => {
+				if (def.addsHediff != null && def.appliedOnFixedBodyParts != null && def.appliedOnFixedBodyParts.Count > 0) {
+					return true;
+				}
+				else {
+					return false;
+				}
+			}));
+
+			// De-dupe the list.
+			HashSet<RecipeDef> recipeSet = new HashSet<RecipeDef>();
+			foreach (var r in recipes) {
+				recipeSet.Add(r);
+			}
+			recipes = new List<RecipeDef>(recipeSet);
+
+			// Iterate the recipes. Populate a lookup with all of the body parts that apply to a given recipe.
+			foreach (var r in recipes) {
+
+				// Get the list of recipe body parts from the dictionary or create it if it doesn't exist.
+				List<BodyPartRecord> bodyPartRecords;
+				if (!recipeBodyParts.TryGetValue(r, out bodyPartRecords)) {
+					bodyPartRecords = new List<BodyPartRecord>();
+					recipeBodyParts.Add(r, bodyPartRecords);
+				}
+				// Add all of the body part records for that recipe to the list.
+				foreach (var bodyPartDef in r.appliedOnFixedBodyParts) {
+					if (bodyPartListLookup.ContainsKey(bodyPartDef)) {
+						List<BodyPartRecord> records = bodyPartListLookup[bodyPartDef];
+						bodyPartRecords.AddRange(records);
+						foreach (var record in records) {
+							replaceableParts.Add(record);
+						}
+					}
+				}
+			}
+
+			// Sort the recipes.
+			recipes.Sort((RecipeDef a, RecipeDef b) => {
+				return a.LabelCap.CompareTo(b.LabelCap);
+			});
+
+			// Classify body parts into all, outside and skin-covered lists.
+			foreach (BodyPartRecord record in bodyDef.AllParts) {
+				allBodyParts.Add(record);
+				if (record.depth == BodyPartDepth.Outside) {
+					allOutsideBodyParts.Add(record);
+				}
+				FieldInfo skinCoveredField = typeof(BodyPartDef).GetField("skinCovered", BindingFlags.Instance | BindingFlags.NonPublic);
+				Boolean value = (Boolean)skinCoveredField.GetValue(record.def);
+				if (value == true) {
+					allSkinCoveredBodyParts.Add(record);
+				}
+			}
+		}
+
+		public List<BodyPartRecord> PartsForRecipe(RecipeDef recipe)
+		{
+			return this.recipeBodyParts[recipe];
+		}
+
+		public IEnumerable<BodyPartRecord> PartAncestors(BodyPartRecord part)
+		{
+			return bodyPartAncestors[part];
+		}
+
+		public bool AncestorIsImplant(BodyPartRecord record, CustomPawn pawn)
+		{
+			foreach (BodyPartRecord ancestor in bodyPartAncestors[record]) {
+				if (pawn.IsImplantedPart(ancestor)) {
+					return true;
+				}
+			}
+			return false;
+		}
+
+		protected void AddAncestors(BodyPartRecord record)
+		{
+			if (bodyPartAncestors.ContainsKey(record)) {
+				return;
+			}
+			else {
+				bodyPartAncestors.Add(record, new HashSet<BodyPartRecord>());
+			}
+			for (BodyPartRecord parentRecord = record.parent; parentRecord != null; parentRecord = parentRecord.parent) {
+				bodyPartAncestors[record].Add(parentRecord);
+			}
+		}
+
+		// TODO: This is problematic for body parts that appear multiple times in a body (i.e. ribs).
+		// Calling this will return the first one that it finds.  There's no distinguishing between multiple
+		// parts of the same type.
+		public BodyPartRecord FindReplaceableBodyPartByName(string name)
+		{
+			foreach (var record in replaceableParts) {
+				if (record.def.defName == name) {
+					return record;
+				}
+			}
+			return null;
+		}
+
+		public BodyPartRecord FirstBodyPartRecord(string bodyPartDefName)
+		{
+			foreach (BodyPartRecord record in bodyDef.AllParts) {
+				if (record.def.defName == bodyPartDefName) {
+					return record;
+				}
+			}
+			return null;
+		}
+
+		public BodyPartRecord FirstBodyPartRecord(BodyPartDef def)
+		{
+			return FirstBodyPartRecord(def.defName);
+		}
+	}
+}

--- a/Source/CostCalculator.cs
+++ b/Source/CostCalculator.cs
@@ -186,7 +186,7 @@ namespace EdB.PrepareCarefully
 			foreach (Implant option in pawn.Implants) {
 
 				// Check if there are any ancestor parts that override the selection.
-				if (PrepareCarefully.Instance.HealthManager.ImplantManager.AncestorIsImplant(option.BodyPartRecord, pawn)) {
+				if (PrepareCarefully.Instance.HealthManager.ImplantManager.AncestorIsImplant(pawn, option.BodyPartRecord)) {
 					continue;
 				}
 

--- a/Source/ImplantManager.cs
+++ b/Source/ImplantManager.cs
@@ -10,119 +10,48 @@ namespace EdB.PrepareCarefully
 {
 	public class ImplantManager
 	{
-		protected Dictionary<BodyPartDef, List<BodyPartRecord>> bodyPartListLookup = new Dictionary<BodyPartDef, List<BodyPartRecord>>();
-		protected List<RecipeDef> recipes = new List<RecipeDef>();
-		protected Dictionary<RecipeDef, List<BodyPartRecord>> recipeBodyParts = new Dictionary<RecipeDef, List<BodyPartRecord>>();
-		protected HashSet<BodyPartRecord> replaceableParts = new HashSet<BodyPartRecord>();
-		protected Dictionary<BodyPartRecord, HashSet<BodyPartRecord>> bodyPartAncestors = new Dictionary<BodyPartRecord, HashSet<BodyPartRecord>>();
-
-		public List<RecipeDef> Recipes {
-			get {
-				return recipes;
-			}
-		}
+		protected Dictionary<ThingDef, BodyPartDictionary> bodyPartDictionaries = new Dictionary<ThingDef, BodyPartDictionary>();
 
 		public ImplantManager()
 		{
-			bodyPartListLookup = new Dictionary<BodyPartDef, List<BodyPartRecord>>();
 
-			// Go through all of the body part records in a human.  Each record is an individual body part, and you
-			// will see more than one instance of each record.  For example, you'll see 12 "Rib" records, one for each
-			// of the 12 rib bones.  For each body part type (i.e. "Rib"), we store a list of each body part record
-			// in a dictionary, so that we can get a list of all records that match a given type/definition.
-			BodyDef bodyDef = BodyDefOf.Human;
-			foreach (BodyPartRecord record in bodyDef.AllParts) {
-				List<BodyPartRecord> records;
-				if (!bodyPartListLookup.TryGetValue(record.def, out records)) {
-					records = new List<BodyPartRecord>();
-					bodyPartListLookup[record.def] = records;
-				}
-				records.Add(record);
-				AddAncestors(record);
-			}
-
-			// Find all recipes that replace a body part.
-			recipes.AddRange(DefDatabase<RecipeDef>.AllDefs.Where((RecipeDef def) => {
-				if (def.addsHediff != null && def.appliedOnFixedBodyParts != null && def.appliedOnFixedBodyParts.Count > 0
-					&& (def.recipeUsers.NullOrEmpty() || def.recipeUsers.Contains(ThingDefOf.Human)) ) {
-					return true;
-				}
-				else {
-					return false;
-				}
-			}));
-
-			// Iterate the recipes. Populate a lookup with all of the body parts that apply to a given recipe.
-			foreach (var r in recipes) {
-
-				// Get the list of recipe body parts from the dictionary or create it if it doesn't exist.
-				List<BodyPartRecord> bodyPartRecords;
-				if (!recipeBodyParts.TryGetValue(r, out bodyPartRecords)) {
-					bodyPartRecords = new List<BodyPartRecord>();
-					recipeBodyParts.Add(r, bodyPartRecords);
-				}
-				// Add all of the body part records for that recipe to the list.
-				foreach (var bodyPartDef in r.appliedOnFixedBodyParts) {
-					if (bodyPartListLookup.ContainsKey(bodyPartDef)) {
-						List<BodyPartRecord> records = bodyPartListLookup[bodyPartDef];
-						bodyPartRecords.AddRange(records);
-						foreach (var record in records) {
-							replaceableParts.Add(record);
-						}
-					}
-				}
-			}
-
-			// Sort the recipes
-			recipes.Sort((RecipeDef a, RecipeDef b) => {
-				return a.LabelCap.CompareTo(b.LabelCap);
-			});
 		}
 
-		public List<BodyPartRecord> PartsForRecipe(RecipeDef recipe)
+		public BodyPartDictionary GetBodyPartDictionary(ThingDef pawnThingDef)
 		{
-			return this.recipeBodyParts[recipe];
+			BodyPartDictionary dictionary;
+			if (!bodyPartDictionaries.TryGetValue(pawnThingDef, out dictionary)) {
+				dictionary = new BodyPartDictionary(pawnThingDef);
+				bodyPartDictionaries.Add(pawnThingDef, dictionary);
+			}
+			return dictionary;
 		}
 
-		public IEnumerable<BodyPartRecord> PartAncestors(BodyPartRecord part)
+		public List<RecipeDef> RecipesForPawn(CustomPawn pawn)
 		{
-			return bodyPartAncestors[part];
+			BodyPartDictionary dictionary = GetBodyPartDictionary(pawn.Pawn.def);
+			return dictionary.ImplantRecipes;
 		}
 
-		public bool AncestorIsImplant(BodyPartRecord record, CustomPawn pawn)
+		public List<BodyPartRecord> PartsForRecipe(Pawn pawn, RecipeDef recipe)
 		{
-			foreach (BodyPartRecord ancestor in bodyPartAncestors[record]) {
-				if (pawn.IsImplantedPart(ancestor)) {
-					return true;
-				}
-			}
-			return false;
+			BodyPartDictionary dictionary = GetBodyPartDictionary(pawn.def);
+			return dictionary.PartsForRecipe(recipe);
 		}
 
-		protected void AddAncestors(BodyPartRecord record)
+		public bool AncestorIsImplant(CustomPawn pawn, BodyPartRecord record)
 		{
-			if (bodyPartAncestors.ContainsKey(record)) {
-				return;
-			}
-			else {
-				bodyPartAncestors.Add(record, new HashSet<BodyPartRecord>());
-			}
-			for (BodyPartRecord parentRecord = record.parent; parentRecord != null; parentRecord = parentRecord.parent) {
-				bodyPartAncestors[record].Add(parentRecord);
-			}
+			BodyPartDictionary dictionary = GetBodyPartDictionary(pawn.Pawn.def);
+			return dictionary.AncestorIsImplant(record, pawn);
 		}
 
 		// TODO: This is problematic for body parts that appear multiple times in a body (i.e. ribs).
 		// Calling this will return the first one that it finds.  There's no distinguishing between multiple
 		// parts of the same type.
-		public BodyPartRecord FindReplaceableBodyPartByName(string name)
+		public BodyPartRecord FindReplaceableBodyPartByName(Pawn pawn, string name)
 		{
-			foreach (var record in replaceableParts) {
-				if (record.def.defName == name) {
-					return record;
-				}
-			}
-			return null;
+			BodyPartDictionary dictionary = GetBodyPartDictionary(pawn.def);
+			return dictionary.FindReplaceableBodyPartByName(name);
 		}
 
 	}

--- a/Source/Panel_Health.cs
+++ b/Source/Panel_Health.cs
@@ -21,7 +21,6 @@ namespace EdB.PrepareCarefully
 		protected Vector2 ContentPadding;
 		protected ScrollView scrollView = new ScrollView();
 
-		public IEnumerable<RecipeDef> implantRecipes;
 		public List<CustomBodyPart> partRemovalList = new List<CustomBodyPart>();
 		protected HashSet<BodyPartRecord> disabledBodyParts = new HashSet<BodyPartRecord>();
 		protected HashSet<InjuryOption> disabledInjuryOptions = new HashSet<InjuryOption>();
@@ -88,8 +87,6 @@ namespace EdB.PrepareCarefully
 			ContentPadding = new Vector2(4, 4);
 			SizeElement = new Vector2(RectScroll.width - (ContentPadding.x * 2), 70);
 
-			implantRecipes = PrepareCarefully.Instance.HealthManager.ImplantManager.Recipes;
-
 			oldInjurySeverities.Add(new InjurySeverity(2));
 			oldInjurySeverities.Add(new InjurySeverity(3));
 			oldInjurySeverities.Add(new InjurySeverity(4));
@@ -148,7 +145,7 @@ namespace EdB.PrepareCarefully
 					else {
 						if (selectedInjury.ValidParts.Count > 0) {
 							foreach (var p in selectedInjury.ValidParts) {
-								BodyPartRecord record = PrepareCarefully.Instance.HealthManager.FirstBodyPartRecord(p);
+								BodyPartRecord record = PrepareCarefully.Instance.HealthManager.FirstBodyPartRecord(customPawn, p);
 								if (record != null) {
 									AddInjuryToPawn(customPawn, selectedInjury, selectedSeverity, record);
 								}
@@ -268,7 +265,7 @@ namespace EdB.PrepareCarefully
 					CloseAction = () => {
 						ResetSeverityOptions(selectedInjury);
 						if (bodyPartSelectionRequired) {
-							bodyPartDialog.Options = PrepareCarefully.Instance.HealthManager.AllSkinCoveredBodyParts;
+							bodyPartDialog.Options = PrepareCarefully.Instance.HealthManager.AllSkinCoveredBodyParts(customPawn);
 							ResetBodyPartEnabledState(bodyPartDialog.Options, customPawn);
 							Find.WindowStack.Add(bodyPartDialog);
 						}
@@ -327,7 +324,7 @@ namespace EdB.PrepareCarefully
 				};
 
 
-				Dialog_Options<RecipeDef> implantRecipeDialog = new Dialog_Options<RecipeDef>(implantRecipes) {
+				Dialog_Options<RecipeDef> implantRecipeDialog = new Dialog_Options<RecipeDef>(PrepareCarefully.Instance.HealthManager.ImplantManager.RecipesForPawn(customPawn)) {
 					ConfirmButtonLabel = "EdB.PrepareCarefully.Next",
 					CancelButtonLabel = "EdB.PrepareCarefully.Cancel",
 					HeaderLabel = "EdB.PrepareCarefully.SelectImplant",
@@ -339,7 +336,7 @@ namespace EdB.PrepareCarefully
 					},
 					SelectAction = (RecipeDef recipe) => {
 						selectedRecipe = recipe;
-						IEnumerable<BodyPartRecord> bodyParts = PrepareCarefully.Instance.HealthManager.ImplantManager.PartsForRecipe(recipe);
+						IEnumerable<BodyPartRecord> bodyParts = PrepareCarefully.Instance.HealthManager.ImplantManager.PartsForRecipe(customPawn.Pawn, recipe);
 						int bodyPartCount = bodyParts.Count();
 						if (bodyParts != null && bodyPartCount > 0) {
 							if (bodyPartCount > 1) {
@@ -418,7 +415,7 @@ namespace EdB.PrepareCarefully
 			disabledBodyParts.Clear();
 			ImplantManager implantManager = PrepareCarefully.Instance.HealthManager.ImplantManager;
 			foreach (var part in parts) {
-				if (pawn.IsImplantedPart(part) || implantManager.AncestorIsImplant(part, pawn)) {
+				if (pawn.IsImplantedPart(part) || implantManager.AncestorIsImplant(pawn, part)) {
 					disabledBodyParts.Add(part);
 				}
 			}

--- a/Source/Randomizer.cs
+++ b/Source/Randomizer.cs
@@ -12,15 +12,33 @@ namespace EdB.PrepareCarefully
 		public Pawn GenerateColonist()
 		{
 			PawnKindDef kindDef = Faction.OfPlayer.def.basicMemberKind;
-			Pawn pawn = PawnGenerator.GeneratePawn(new PawnGenerationRequest(kindDef, Faction.OfPlayer,
+			Pawn result = PawnGenerator.GeneratePawn(new PawnGenerationRequest(kindDef, Faction.OfPlayer,
 					PawnGenerationContext.PlayerStarter, null, true, false, false, false, false, false, 0f, false, true,
 			        false, null, null, null, null, null, null));
-			return pawn;
+			return result;
+		}
+
+		public Pawn GenerateKindOfColonist(PawnKindDef kindDef)
+		{
+			Pawn result = PawnGenerator.GeneratePawn(new PawnGenerationRequest(kindDef, Faction.OfPlayer,
+					PawnGenerationContext.PlayerStarter, null, true, false, false, false, false, false, 0f, false, true,
+					false, null, null, null, null, null, null));
+			return result;
+		}
+
+		public Pawn GenerateSameKindOfColonist(CustomPawn pawn)
+		{
+			return GenerateKindOfColonist(pawn.Pawn.kindDef);
+		}
+
+		public Pawn GenerateSameKindOfColonist(Pawn pawn)
+		{
+			return GenerateKindOfColonist(pawn.kindDef);
 		}
 
 		public void RandomizeAll(CustomPawn customPawn)
 		{
-			Pawn pawn = GenerateColonist();
+			Pawn pawn = GenerateSameKindOfColonist(customPawn);
 			customPawn.InitializeWithPawn(pawn);
 		}
 
@@ -46,7 +64,7 @@ namespace EdB.PrepareCarefully
 
 		public void RandomizeTraits(CustomPawn customPawn)
 		{
-			Pawn pawn = GenerateColonist();
+			Pawn pawn = GenerateSameKindOfColonist(customPawn);
 			List<Trait> traits = pawn.story.traits.allTraits;
 			if (traits.Count > 0) {
 				customPawn.SetTrait(0, traits[0]);
@@ -73,7 +91,7 @@ namespace EdB.PrepareCarefully
 			Pawn pawn;
 			int tries = 0;
 			do {
-				pawn = GenerateColonist();
+				pawn = GenerateSameKindOfColonist(customPawn);
 				tries++;
 			}
 			while (pawn.gender != customPawn.Gender && tries < 1000);
@@ -100,9 +118,8 @@ namespace EdB.PrepareCarefully
 
 		public void RandomizeName(CustomPawn customPawn)
 		{
-			Pawn pawn = GenerateColonist();
+			Pawn pawn = GenerateSameKindOfColonist(customPawn);
 			pawn.gender = customPawn.Gender;
-			//Name name = NameGenerator.GeneratePawnName(pawn, NameStyle.Full, null);
 			Name name = PawnBioAndNameGenerator.GeneratePawnName(pawn, NameStyle.Full, null);
 			NameTriple nameTriple = name as NameTriple;
 			customPawn.Name = nameTriple;

--- a/Source/Version3/PresetLoaderVersion3.cs
+++ b/Source/Version3/PresetLoaderVersion3.cs
@@ -187,6 +187,15 @@ namespace EdB.PrepareCarefully
 			Pawn source = new Randomizer().GenerateColonist();
 
 			CustomPawn pawn = new CustomPawn(source);
+
+			ThingDef pawnThingDef = ThingDefOf.Human;
+			if (record.thingDef != null) {
+				ThingDef thingDef = DefDatabase<ThingDef>.GetNamedSilentFail(record.thingDef);
+				if (thingDef != null) {
+					pawnThingDef = thingDef;
+				}
+			}
+
 			pawn.Gender = record.gender;
 			if (record.age > 0) {
 				pawn.ChronologicalAge = record.age;
@@ -337,7 +346,7 @@ namespace EdB.PrepareCarefully
 
 			for (int i = 0; i < record.implants.Count; i++) {
 				SaveRecordImplantV3 implantRecord = record.implants[i];
-				BodyPartRecord bodyPart = PrepareCarefully.Instance.HealthManager.ImplantManager.FindReplaceableBodyPartByName(implantRecord.bodyPart);
+				BodyPartRecord bodyPart = PrepareCarefully.Instance.HealthManager.ImplantManager.FindReplaceableBodyPartByName(pawn.Pawn, implantRecord.bodyPart);
 				if (bodyPart == null) {
 					Log.Warning("Could not find replaceable body part definition \"" + implantRecord.bodyPart + "\"");
 					Failed = true;
@@ -385,7 +394,7 @@ namespace EdB.PrepareCarefully
 				}
 				BodyPartRecord bodyPart = null;
 				if (injuryRecord.bodyPart != null) {
-					bodyPart = PrepareCarefully.Instance.HealthManager.FirstBodyPartRecord(injuryRecord.bodyPart);
+					bodyPart = PrepareCarefully.Instance.HealthManager.FirstBodyPartRecord(pawn, injuryRecord.bodyPart);
 					if (bodyPart == null) {
 						Log.Warning("Could not find body part \"" + injuryRecord.bodyPart + "\"");
 						Failed = true;

--- a/Source/Version3/SaveRecordPawnV3.cs
+++ b/Source/Version3/SaveRecordPawnV3.cs
@@ -9,6 +9,7 @@ namespace EdB.PrepareCarefully
 {
 	public class SaveRecordPawnV3 : IExposable
 	{
+		public string thingDef;
 		public Gender gender;
 		public string adulthood;
 		public string childhood;
@@ -53,6 +54,7 @@ namespace EdB.PrepareCarefully
 			else {
 				this.adulthood = pawn.LastSelectedAdulthood.identifier;
 			}
+			this.thingDef = pawn.Pawn.def.defName;
 			this.childhood = pawn.Childhood.identifier;
 			this.skinColor = pawn.Pawn.story.SkinColor;
 			this.melanin = pawn.Pawn.story.melanin;
@@ -100,6 +102,7 @@ namespace EdB.PrepareCarefully
 
 		public void ExposeData()
 		{
+			Scribe_Values.LookValue<string>(ref this.thingDef, "thingDef", ThingDefOf.Human.defName, false);
 			Scribe_Values.LookValue<Gender>(ref this.gender, "gender", Gender.Male, false);
 			Scribe_Values.LookValue<string>(ref this.childhood, "childhood", null, false);
 			Scribe_Values.LookValue<string>(ref this.adulthood, "adulthood", null, false);


### PR DESCRIPTION
Better support for non-human pawns to try to prevent errors when playing with mods:
- Body parts and available implants are now computed based on the pawn's ThingDef.
- The pawn copying and randomizing code now duplicates the pawn using a matching PawnKindDef.
- The pawn's ThingDef is now saved with the preset.