### PR TITLE
Screen blackout fix

### DIFF
--- a/Source/CustomPawn.cs
+++ b/Source/CustomPawn.cs
@@ -59,6 +59,7 @@ namespace EdB.PrepareCarefully
 		protected List<Injury> injuries = new List<Injury>();
 		public List<CustomBodyPart> bodyParts = new List<CustomBodyPart>();
 		protected ThingCache thingCache = new ThingCache();
+		protected bool portraitDirty = true;
 
 		public CustomPawn()
 		{
@@ -103,6 +104,19 @@ namespace EdB.PrepareCarefully
 			get {
 				return bodyParts;
 			}
+		}
+
+		public void UpdatePortrait()
+		{
+			if (portraitDirty) {
+				portraitDirty = false;
+				ClearCachedPortrait();
+			}
+		}
+
+		protected void MarkPortraitAsDirty()
+		{
+			portraitDirty = true;
 		}
 
 		public void InitializeWithPawn(Pawn pawn)
@@ -170,6 +184,8 @@ namespace EdB.PrepareCarefully
 			if (adulthood == null) {
 				this.adulthood = Randomizer.RandomAdulthood(this);
 			}
+
+			MarkPortraitAsDirty();
 		}
 
 		public void InitializeSkillLevelsAndPassions()
@@ -624,7 +640,7 @@ namespace EdB.PrepareCarefully
 		private void ResetApparel()
 		{
 			CopyApparelToPawn(this.pawn);
-			ClearCachedPortrait();
+			MarkPortraitAsDirty();
 		}
 
 		public ThingDef GetSelectedApparel(int layer) {
@@ -850,7 +866,7 @@ namespace EdB.PrepareCarefully
 				// Need to use reflection to set the private field.
 				typeof(Pawn_StoryTracker).GetField("headGraphicPath", BindingFlags.Instance | BindingFlags.NonPublic).SetValue(pawn.story, value);
 				ResetHead();
-				ClearCachedPortrait();
+				MarkPortraitAsDirty();
 			}
 		}
 
@@ -923,7 +939,7 @@ namespace EdB.PrepareCarefully
 			set {
 				pawn.story.bodyType = value;
 				ResetBodyType();
-				ClearCachedPortrait();
+				MarkPortraitAsDirty();
 			}
 		}
 
@@ -935,7 +951,7 @@ namespace EdB.PrepareCarefully
 				if (pawn.gender != value) {
 					pawn.gender = value;
 					ResetGender();
-					ClearCachedPortrait();
+					MarkPortraitAsDirty();
 				}
 			}
 		}
@@ -953,7 +969,7 @@ namespace EdB.PrepareCarefully
 			set {
 				pawn.story.melanin = value;
 				this.colors[PawnLayers.BodyType] = this.colors[PawnLayers.HeadType] = pawn.story.SkinColor;
-				ClearCachedPortrait();
+				MarkPortraitAsDirty();
 			}
 		}
 
@@ -963,7 +979,7 @@ namespace EdB.PrepareCarefully
 			}
 			set {
 				pawn.story.hairDef = value;
-				ClearCachedPortrait();
+				MarkPortraitAsDirty();
 			}
 		}
 
@@ -1036,8 +1052,6 @@ namespace EdB.PrepareCarefully
 		protected void ResetBodyType()
 		{
 			BodyType bodyType = pawn.story.bodyType;
-			Graphic bodyTypeGraphic = GraphicGetter_NakedHumanlike.GetNakedBodyGraphic(bodyType, ShaderDatabase.Cutout,
-					pawn.story.SkinColor);
 		}
 
 		public string ResetIncapableOf()
@@ -1312,7 +1326,7 @@ namespace EdB.PrepareCarefully
 			ClearCachedLifeStage();
 			ClearCachedDisabledWorkTypes(this.pawn.story);
 			ClearCachedDisabledSkillRecords(this.pawn);
-			ClearCachedPortrait();
+			MarkPortraitAsDirty();
 		}
 
 		public void ClearCachedAbilities() {

--- a/Source/Page_ConfigureStartingPawnsCarefully.cs
+++ b/Source/Page_ConfigureStartingPawnsCarefully.cs
@@ -478,6 +478,8 @@ namespace EdB.PrepareCarefully
 					}, true, null, true));
 				}
 			);
+			
+			CurrentPawn.UpdatePortrait();
 		}
 
 		public TabRecord DrawTabs(Rect baseRect, IEnumerable<TabRecord> tabsEnum)
@@ -840,7 +842,6 @@ namespace EdB.PrepareCarefully
 				}
 				Find.WindowStack.Add(new FloatMenu(list, null, false));
 			}
-
 			Rect portraitRect = new Rect(28, 60, 192, 192);
 			GUI.DrawTexture(portraitRect, Textures.TexturePortraitBackground);
 
@@ -1142,13 +1143,29 @@ namespace EdB.PrepareCarefully
 			GUI.DrawTexture(rect.ContractedBy(1), BaseContent.WhiteTex);
 
 			GUI.color = Color.red;
+			float originalR = currentColor.r;
+			float originalG = currentColor.g;
+			float originalB = currentColor.b;
 			float r = GUI.HorizontalSlider(new Rect(rect.x + 56, rect.y - 1, 136, 16), currentColor.r, 0, 1);
 			GUI.color = Color.green;
 			float g = GUI.HorizontalSlider(new Rect(rect.x + 56, rect.y + 19, 136, 16), currentColor.g, 0, 1);
 			GUI.color = Color.blue;
 			float b = GUI.HorizontalSlider(new Rect(rect.x + 56, rect.y + 39, 136, 16), currentColor.b, 0, 1);
-			SetColor(new Color(r, g, b));
+			if (!CloseEnough(r, originalR) || !CloseEnough(g, originalG) || !CloseEnough(b, originalB)) {
+				SetColor(new Color(r, g, b));
+			}
+
 			GUI.color = Color.white;
+		}
+
+		protected bool CloseEnough(float a, float b)
+		{
+			if (a > b - 0.0001f && a < b + 0.0001f) {
+				return true;
+			}
+			else {
+				return false;
+			}
 		}
 
 		protected void SetColor(Color color)
@@ -2143,10 +2160,6 @@ namespace EdB.PrepareCarefully
 		{
 			get {
 				CustomPawn customPawn = CurrentPawn;
-				//if (pawnLayerLabelIndex == selectedPawnLayer && pawnLayerLabelModel == customPawn && pawnLayerLabel != null) {
-				//	return pawnLayerLabel;
-				//}
-
 				string label = "EdB.None".Translate();
 				if (selectedPawnLayer == PawnLayers.BodyType) {
 					label = bodyTypeLabels[customPawn.BodyType];


### PR DESCRIPTION
- Added fix for screen blackout when selecting a pawn layer that has an RGB color slider (only a problem when using some other mods)
- Updated portrait cache clearing to only clear the cache once per frame.
- Removed some unused/commented-out code.