### PR TITLE
Fixes for loading pre-Alpha 17 presets and fixes for downed colonists

### DIFF
--- a/EdBPrepareCarefully.csproj
+++ b/EdBPrepareCarefully.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>EdB.PrepareCarefully</RootNamespace>
     <AssemblyName>EdBPrepareCarefully</AssemblyName>
-    <ReleaseVersion>0.17.0.1</ReleaseVersion>
+    <ReleaseVersion>0.17.0.2</ReleaseVersion>
     <UseMSBuildEngine>False</UseMSBuildEngine>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
   </PropertyGroup>

--- a/EdBPrepareCarefully.sln
+++ b/EdBPrepareCarefully.sln
@@ -197,6 +197,6 @@ Global
 		$29.IncludeStaticEntities = True
 		$0.VersionControlPolicy = $31
 		$31.inheritsSet = Mono
-		version = 0.17.0.1
+		version = 0.17.0.2
 	EndGlobalSection
 EndGlobal

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -17,7 +17,7 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion("0.17.0.1")]
+[assembly: AssemblyVersion("0.17.0.2")]
 
 // The following attributes are used to specify the signing key for the assembly,
 // if desired. See the Mono documentation for more information about signing.

--- a/Resources/About/About.xml
+++ b/Resources/About/About.xml
@@ -8,6 +8,6 @@
 
 If you get a set of starting colonists that you like, save them as a preset so that you can start your game the same way next time.
 
-[Version 0.17.0.1]
+[Version 0.17.0.2]
 	</description>
 </ModMetaData>

--- a/Resources/Languages/English/Keyed/EdBPrepareCarefully.xml
+++ b/Resources/Languages/English/Keyed/EdBPrepareCarefully.xml
@@ -59,6 +59,7 @@ Your colonist customizations will be ignored.</EdB.PC.Dialog.ModConfigProblem.De
   <EdB.PC.Dialog.Preset.DeleteTooltip>Delete this Preset</EdB.PC.Dialog.Preset.DeleteTooltip>
   <EdB.PC.Dialog.Preset.Error.Failed>Failed to load colonists from the preset.  Check that all required mods are enabled.</EdB.PC.Dialog.Preset.Error.Failed>
   <EdB.PC.Dialog.Preset.Error.PreAlpha13NotSupported>Pre-alpha 13 versions of presets are not supported.</EdB.PC.Dialog.Preset.Error.PreAlpha13NotSupported>
+  <EdB.PC.Dialog.Preset.Error.RelationshipFailed>Could not load a custom relationship from the preset</EdB.PC.Dialog.Preset.Error.RelationshipFailed>
   <EdB.PC.Dialog.Preset.Error.ThingDefFailed>Could not fully load preset.  Check that all required mods are enabled.</EdB.PC.Dialog.Preset.Error.ThingDefFailed>
   <EdB.PC.Dialog.Preset.Loaded>Loaded preset {0}</EdB.PC.Dialog.Preset.Loaded>
 

--- a/Source/CostCalculator.cs
+++ b/Source/CostCalculator.cs
@@ -117,18 +117,6 @@ namespace EdB.PrepareCarefully {
             cost.marketValue = pawn.Pawn.MarketValue;
             cost.marketValue += 300;
 
-            // Reduce cost if random injuries have been chosen.
-            if (pawn.RandomInjuries) {
-                float ageMultiplier = pawn.BiologicalAge;
-                if (ageMultiplier > 100) {
-                    ageMultiplier = 100;
-                }
-                float injuryValue = Mathf.Pow(ageMultiplier, 1.177455f);
-                injuryValue = injuryValue / 10f;
-                injuryValue = Mathf.Floor(injuryValue) * 10f;
-                cost.marketValue -= injuryValue;
-            }
-
             // Calculate passion cost.  Each passion above 8 makes all passions
             // cost more.  Minor passion counts as one passion.  Major passion
             // counts as 3.
@@ -157,8 +145,8 @@ namespace EdB.PrepareCarefully {
             cost.marketValue += levelCost * passionLevelCount;
 
             // Calculate trait cost.
-            if (pawn.Traits.Count > 3) {
-                double extraTraitCount = (double)(pawn.Traits.Count - 3);
+            if (pawn.Traits.Count() > 3) {
+                double extraTraitCount = (double)(pawn.Traits.Count() - 3);
                 cost.marketValue += extraTraitCount * 75.0;
             }
 

--- a/Source/CustomPawn.cs
+++ b/Source/CustomPawn.cs
@@ -40,7 +40,6 @@ namespace EdB.PrepareCarefully {
         protected Dictionary<EquipmentKey, Color> colorCache = new Dictionary<EquipmentKey, Color>();
         protected string apparelConflictText = null;
         protected List<ApparelConflict> apparelConflicts = new List<ApparelConflict>();
-        protected bool randomInjuries = false;
 
         // Keep track of the most recently selected adulthood option so that if the user updates the pawn's
         // age in a way that switches them back and forth from adult to child (which nulls out the adulthood
@@ -249,9 +248,8 @@ namespace EdB.PrepareCarefully {
 
         public void UpdateSkillLevelsForNewBackstoryOrTrait() {
             ComputeSkillLevelModifiers();
-            // Clear caches.
             ResetCachedIncapableOf();
-            pawn.health.capacities.Clear();
+            ClearPawnCaches();
         }
 
         // Computes the skill level modifiers that the pawn gets from the selected backstories and traits.
@@ -485,16 +483,7 @@ namespace EdB.PrepareCarefully {
                 return pawn.LabelShort;
             }
         }
-
-        public bool RandomInjuries {
-            get {
-                return randomInjuries;
-            }
-            set {
-                randomInjuries = value;
-            }
-        }
-
+        
         public IEnumerable<Implant> Implants {
             get {
                 return implants;
@@ -930,13 +919,14 @@ namespace EdB.PrepareCarefully {
             ResetTraits();
         }
         
-        public List<Trait> Traits {
+        public IEnumerable<Trait> Traits {
             get {
                 return this.Pawn.story.traits.allTraits;
             }
         }
 
         protected void ResetTraits() {
+            SyncBodyParts();
             UpdateSkillLevelsForNewBackstoryOrTrait();
         }
 
@@ -1158,6 +1148,7 @@ namespace EdB.PrepareCarefully {
             foreach (var implant in implants) {
                 implant.AddToPawn(this, pawn);
             }
+            ClearPawnCaches();
         }
 
         public void RemoveCustomBodyParts(CustomBodyPart part) {
@@ -1216,4 +1207,3 @@ namespace EdB.PrepareCarefully {
         }
     }
 }
-

--- a/Source/GenStep_ScenParts.cs
+++ b/Source/GenStep_ScenParts.cs
@@ -35,7 +35,7 @@ namespace EdB.PrepareCarefully {
                 }
 
                 SpawnColonistsWithEquipment(map, arriveMethodPart);
-                ApplyColonistHealthCustomizations();
+                //ApplyColonistHealthCustomizations();
                 PrepForMapGen();
                 SpawnStartingResources(map);
             }
@@ -324,28 +324,6 @@ namespace EdB.PrepareCarefully {
             // Used to do this in Alpha 13.  Still necessary?
             foreach (Pawn current in Find.GameInitData.startingPawns) {
                 PawnComponentsUtility.AddAndRemoveDynamicComponents(current, false);
-            }
-        }
-
-        // Add health customizations.
-        public void ApplyColonistHealthCustomizations() {
-            int index = 0;
-            foreach (Pawn pawn in Find.GameInitData.startingPawns) {
-                pawn.health = new Pawn_HealthTracker(pawn);
-                CustomPawn customPawn = PrepareCarefully.Instance.Pawns[index++];
-                if (customPawn.RandomInjuries) {
-                    AgeInjuryUtility.GenerateRandomOldAgeInjuries(pawn, true);
-                }
-            }
-            for (int i = 0; i < PrepareCarefully.Instance.Pawns.Count; i++) {
-                CustomPawn customPawn = PrepareCarefully.Instance.Pawns[i];
-                Pawn pawn = Find.GameInitData.startingPawns[i];
-                foreach (Injury injury in customPawn.Injuries) {
-                    injury.AddToPawn(customPawn, pawn);
-                }
-                foreach (Implant implant in customPawn.Implants) {
-                    implant.AddToPawn(customPawn, pawn);
-                }
             }
         }
 

--- a/Source/PanelTraits.cs
+++ b/Source/PanelTraits.cs
@@ -191,7 +191,7 @@ namespace EdB.PrepareCarefully {
             // Add trait button.
             Rect addRect = new Rect(randomizeRect.x - 24, 12, 16, 16);
             Style.SetGUIColorForButton(addRect);
-            bool addButtonEnabled = (state.CurrentPawn != null && state.CurrentPawn.Traits.Count < 4);
+            bool addButtonEnabled = (state.CurrentPawn != null && state.CurrentPawn.Traits.Count() < 4);
             if (!addButtonEnabled) {
                 GUI.color = Style.ColorButtonDisabled;
             }

--- a/Source/Version3/ColonistLoaderVersion3.cs
+++ b/Source/Version3/ColonistLoaderVersion3.cs
@@ -33,9 +33,13 @@ namespace EdB.PrepareCarefully {
                 throw e;
             }
             finally {
-                Scribe.mode = LoadSaveMode.Inactive;
+                // I don't fully understand how these cross-references and saveables are resolved, but
+                // if we don't clear them out, we get null pointer exceptions.
                 HashSet<IExposable> saveables = (HashSet<IExposable>)(typeof(PostLoadIniter).GetField("saveablesToPostLoad", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(Scribe.loader.initer));
                 saveables.Clear();
+                List<IExposable> crossReferencingExposables = (List<IExposable>)(typeof(CrossRefHandler).GetField("crossReferencingExposables", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(Scribe.loader.crossRefs));
+                crossReferencingExposables.Clear();
+                Scribe.loader.FinalizeLoading();
             }
 
             if (pawnRecord == null) {

--- a/Source/Version3/SaveRecordPawnV3.cs
+++ b/Source/Version3/SaveRecordPawnV3.cs
@@ -91,7 +91,6 @@ namespace EdB.PrepareCarefully {
                     this.apparelColors.Add(color);
                 }
             }
-            this.randomInjuries = pawn.RandomInjuries;
             foreach (Implant implant in pawn.Implants) {
                 this.implants.Add(new SaveRecordImplantV3(implant));
             }
@@ -130,7 +129,6 @@ namespace EdB.PrepareCarefully {
             Scribe_Collections.Look<int>(ref this.apparelLayers, "apparelLayers", LookMode.Value, null);
             Scribe_Collections.Look<string>(ref this.apparelStuff, "apparelStuff", LookMode.Value, null);
             Scribe_Collections.Look<Color>(ref this.apparelColors, "apparelColors", LookMode.Value, null);
-            Scribe_Values.Look<bool>(ref this.randomInjuries, "randomInjuries", false, true);
 
             if (Scribe.mode == LoadSaveMode.Saving) {
                 Scribe_Collections.Look<SaveRecordImplantV3>(ref this.implants, "implants", LookMode.Deep, null);


### PR DESCRIPTION
- Fixed issues with loading old presets
   - Added null pointer check for the new "otherPawns" section (missing from older presets)
   - Added replacement logic for the renamed survival rifle thingDef.
- Fixed issued where the pawn's appearance did not properly reflect whether or not they are downed.
   - Re-applying hediffs and clearing caches when changing traits and adding health conditions
- Removed redundant code that re-applies hediffs right before spawning colonists into the map.