### PR TITLE
Missing work types warning

### DIFF
--- a/Resources/Languages/English/Keyed/EdBPrepareCarefully.xml
+++ b/Resources/Languages/English/Keyed/EdBPrepareCarefully.xml
@@ -158,6 +158,12 @@
 
   <EdB.PC.Panel.Incapable.None>None</EdB.PC.Panel.Incapable.None>
   <EdB.PC.Panel.Incapable.Title>Incapable of</EdB.PC.Panel.Incapable.Title>
+  <EdB.PC.Panel.Incapable.Warning>None of your pawns are capable of the following work types that are considered to be required by the vanilla game.
+
+{0}
+
+You can play the game with your colonists as they are, but you may see an error message when you start the scenario.</EdB.PC.Panel.Incapable.Warning>
+  <EdB.PC.Panel.Incapable.WarningItem> - {0}</EdB.PC.Panel.Incapable.WarningItem>
 
   <EdB.PC.Panel.LoadSave.Load>Load Character</EdB.PC.Panel.LoadSave.Load>
   <EdB.PC.Panel.LoadSave.Save>Save Character</EdB.PC.Panel.LoadSave.Save>

--- a/Source/Controller.cs
+++ b/Source/Controller.cs
@@ -32,6 +32,7 @@ namespace EdB.PrepareCarefully {
             subcontrollerCharacters = new ControllerPawns(state);
             subcontrollerEquipment = new ControllerEquipment(state);
             subcontrollerRelationships = new ControllerRelationships(state);
+            CheckPawnCapabilities();
         }
 
         private AcceptanceReport CanStart() {
@@ -91,6 +92,7 @@ namespace EdB.PrepareCarefully {
                 }));
                 state.CurrentPawnIndex = 0;
             }
+            CheckPawnCapabilities();
         }
 
         public void SavePreset(string name) {
@@ -265,6 +267,34 @@ namespace EdB.PrepareCarefully {
             else {
                 return false;
             }
+        }
+
+        // Copied from GameInitData.PrepForMapGen() to check if any pawns are missing required work types.
+        public void CheckPawnCapabilities() {
+            List<string> missingWorkTypes = null;
+            foreach (WorkTypeDef w in DefDatabase<WorkTypeDef>.AllDefs) {
+                if (!w.alwaysStartActive) {
+                    bool flag = false;
+                    foreach (CustomPawn current4 in PrepareCarefully.Instance.Pawns) {
+                        if (!current4.Pawn.story.WorkTypeIsDisabled(w)) {
+                            flag = true;
+                        }
+                    }
+                    if (!flag) {
+                        IEnumerable<CustomPawn> source = from col in PrepareCarefully.Instance.Pawns where !col.Pawn.story.WorkTypeIsDisabled(w) select col;
+                        if (source.Any<CustomPawn>()) {
+                            CustomPawn pawn = source.InRandomOrder(null).MaxBy((CustomPawn c) => c.Pawn.skills.AverageOfRelevantSkillsFor(w));
+                        }
+                        else if (w.requireCapableColonist) {
+                            if (missingWorkTypes == null) {
+                                missingWorkTypes = new List<string>();
+                            }
+                            missingWorkTypes.Add(w.gerundLabel);
+                        }
+                    }
+                }
+            }
+            state.MissingWorkTypes = missingWorkTypes;
         }
     }
 }

--- a/Source/GenStep_CustomScatterThings.cs
+++ b/Source/GenStep_CustomScatterThings.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 using Verse;
 
 namespace EdB.PrepareCarefully {
+    // Duplicate of GenStep_ScatterThings with a radius field to allow for a large spawn area.
     public class GenStep_CustomScatterThings : GenStep_Scatterer {
         //
         // Static Fields

--- a/Source/Page_PrepareCarefully.cs
+++ b/Source/Page_PrepareCarefully.cs
@@ -226,7 +226,9 @@ namespace EdB.PrepareCarefully {
             tabViewPawns.PanelAppearance.GenderUpdated += pawns.UpdateGender;
 
             tabViewPawns.PanelBackstory.BackstoryUpdated += pawns.UpdateBackstory;
+            tabViewPawns.PanelBackstory.BackstoryUpdated += (BackstorySlot slot, Backstory backstory) => { controller.CheckPawnCapabilities(); };
             tabViewPawns.PanelBackstory.BackstoriesRandomized += pawns.RandomizeBackstories;
+            tabViewPawns.PanelBackstory.BackstoriesRandomized += () => { controller.CheckPawnCapabilities(); };
 
             tabViewPawns.PanelPawnList.PawnSelected += pawns.SelectPawn;
             tabViewPawns.PanelPawnList.PawnSelected += (CustomPawn pawn) => { tabViewPawns.PanelName.ClearSelection(); };
@@ -236,7 +238,9 @@ namespace EdB.PrepareCarefully {
             tabViewPawns.PanelPawnList.AddingPawn += pawns.AddingPawn;
             tabViewPawns.PanelPawnList.AddingFactionPawn += pawns.AddFactionPawn;
             tabViewPawns.PanelPawnList.PawnDeleted += pawns.DeletePawn;
+            tabViewPawns.PanelPawnList.PawnDeleted += (CustomPawn pawn) => { controller.CheckPawnCapabilities(); };
             pawns.PawnAdded += (CustomPawn pawn) => { tabViewPawns.PanelPawnList.ScrollToBottom(); tabViewPawns.PanelPawnList.SelectPawn(pawn); };
+            pawns.PawnAdded += (CustomPawn pawn) => { controller.CheckPawnCapabilities(); };
 
             tabViewPawns.PanelHealth.InjuryAdded += pawns.AddInjury;
             tabViewPawns.PanelHealth.InjuryAdded += (Injury i) => { tabViewPawns.PanelHealth.ScrollToBottom(); };
@@ -249,8 +253,10 @@ namespace EdB.PrepareCarefully {
             tabViewPawns.PanelName.NameRandomized += pawns.RandomizeName;
 
             tabViewPawns.PanelRandomize.RandomizeAllClicked += pawns.RandomizeAll;
+            tabViewPawns.PanelRandomize.RandomizeAllClicked += () => { controller.CheckPawnCapabilities(); };
 
             tabViewPawns.PanelSaveLoad.CharacterLoaded += pawns.LoadCharacter;
+            tabViewPawns.PanelSaveLoad.CharacterLoaded += (string filename) => { controller.CheckPawnCapabilities(); };
             tabViewPawns.PanelSaveLoad.CharacterSaved += pawns.SaveCharacter;
 
             tabViewPawns.PanelSkills.SkillLevelUpdated += pawns.UpdateSkillLevel;

--- a/Source/PanelIncapableOf.cs
+++ b/Source/PanelIncapableOf.cs
@@ -1,10 +1,14 @@
 using RimWorld;
 using System;
+using System.Collections.Generic;
 using UnityEngine;
 using Verse;
 namespace EdB.PrepareCarefully {
     public class PanelIncapableOf : PanelBase {
         protected Rect RectText;
+        protected Vector2 SizeAlert = new Vector2(20, 20);
+        protected List<string> cachedMissingWorkTypes = null;
+        protected string missingWorkTypeString = null;
         public PanelIncapableOf() {
         }
         public override string PanelHeader {
@@ -33,6 +37,21 @@ namespace EdB.PrepareCarefully {
             Text.WordWrap = true;
             Text.Font = GameFont.Small;
             Widgets.Label(RectText, incapable);
+
+            if (state.MissingWorkTypes != null) {
+                GUI.color = Color.white;
+                Rect alertRect = new Rect(PanelRect.width - SizeAlert.x - 12, 10, SizeAlert.x, SizeAlert.y);
+                GUI.DrawTexture(alertRect, Textures.TextureAlertSmall);
+                if (cachedMissingWorkTypes != state.MissingWorkTypes) {
+                    cachedMissingWorkTypes = state.MissingWorkTypes;
+                    missingWorkTypeString = "";
+                    foreach (var type in state.MissingWorkTypes) {
+                        missingWorkTypeString += "EdB.PC.Panel.Incapable.WarningItem".Translate(new object[] { type }) + "\n";
+                    }
+                    missingWorkTypeString = missingWorkTypeString.TrimEndNewlines();
+                }
+                TooltipHandler.TipRegion(alertRect, "EdB.PC.Panel.Incapable.Warning".Translate(new object[] { missingWorkTypeString }));
+            }
         }
     }
 }

--- a/Source/PanelPawnList.cs
+++ b/Source/PanelPawnList.cs
@@ -250,5 +250,6 @@ namespace EdB.PrepareCarefully {
         public void ScrollToBottom() {
             scrollView.ScrollToBottom();
         }
+        
     }
 }

--- a/Source/State.cs
+++ b/Source/State.cs
@@ -1,6 +1,8 @@
-﻿using System;
+﻿using RimWorld;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using Verse;
 
 namespace EdB.PrepareCarefully {
     public class State {
@@ -8,6 +10,7 @@ namespace EdB.PrepareCarefully {
         
         protected List<string> errors = new List<string>();
         protected List<string> messages = new List<string>();
+        private List<string> missingWorkTypes = null;
 
         public Page_PrepareCarefully Page {
             get;
@@ -48,6 +51,15 @@ namespace EdB.PrepareCarefully {
 
         public void AddError(string error) {
             this.errors.Add(error);
+        }
+
+        public List<string> MissingWorkTypes {
+            get {
+                return missingWorkTypes;
+            }
+            set {
+                missingWorkTypes = value;
+            }
         }
 
         public void ClearErrors() {


### PR DESCRIPTION
Added a warning to the IncapableOf panel to warn the user if their pawns are all missing work types that are considered required.  Adding the alert so that the user knows what happened when they get the subsequent error when the map generates.