### PR TITLE
Changes to profession label

### DIFF
--- a/Source/CustomPawn.cs
+++ b/Source/CustomPawn.cs
@@ -688,6 +688,17 @@ namespace EdB.PrepareCarefully {
         public string ProfessionLabel {
             get {
                 if (IsAdult) {
+                    return Adulthood.Title;
+                }
+                else {
+                    return Childhood.Title;
+                }
+            }
+        }
+
+        public string ProfessionLabelShort {
+            get {
+                if (IsAdult) {
                     return Adulthood.TitleShort;
                 }
                 else {

--- a/Source/DialogSelectParentChildPawn.cs
+++ b/Source/DialogSelectParentChildPawn.cs
@@ -177,8 +177,8 @@ namespace EdB.PrepareCarefully {
                             "EdB.PC.Pawn.AgeWithChronological".Translate(new object[] { pawn.BiologicalAge, pawn.ChronologicalAge }) :
                             "EdB.PC.Pawn.AgeWithoutChronological".Translate(new object[] { pawn.BiologicalAge });
                         description = pawn.Gender != Gender.None ?
-                            "EdB.PC.Pawn.PawnDescriptionWithGender".Translate(new object[] { pawn.ProfessionLabel, pawn.Gender.GetLabel(), age }) :
-                            "EdB.PC.Pawn.PawnDescriptionNoGender".Translate(new object[] { pawn.ProfessionLabel, age });
+                            "EdB.PC.Pawn.PawnDescriptionWithGender".Translate(new object[] { pawn.ProfessionLabelShort, pawn.Gender.GetLabel(), age }) :
+                            "EdB.PC.Pawn.PawnDescriptionNoGender".Translate(new object[] { pawn.ProfessionLabelShort, age });
                     }
                     else {
                         string profession = "EdB.PC.Pawn.HiddenPawnProfession".Translate();

--- a/Source/PanelRelationshipsOther.cs
+++ b/Source/PanelRelationshipsOther.cs
@@ -112,7 +112,7 @@ namespace EdB.PrepareCarefully {
             Text.Font = GameFont.Tiny;
             Text.Anchor = TextAnchor.LowerCenter;
             GUI.color = Style.ColorText;
-            Widgets.Label(sourceProfessionName, relationship.source.ProfessionLabel);
+            Widgets.Label(sourceProfessionName, relationship.source.ProfessionLabelShort);
             GUI.color = Color.white;
 
             Rect sourcePortraitRect = sourcePawnRect.InsetBy(6);
@@ -146,7 +146,7 @@ namespace EdB.PrepareCarefully {
             Text.Font = GameFont.Tiny;
             Text.Anchor = TextAnchor.LowerCenter;
             GUI.color = Style.ColorText;
-            Widgets.Label(targetProfessionName, relationship.target.ProfessionLabel);
+            Widgets.Label(targetProfessionName, relationship.target.ProfessionLabelShort);
             GUI.color = Color.white;
             
             Rect targetPortraitRect = targetPawnRect.InsetBy(6);

--- a/Source/PanelRelationshipsParentChild.cs
+++ b/Source/PanelRelationshipsParentChild.cs
@@ -475,13 +475,13 @@ namespace EdB.PrepareCarefully {
         }
         private string GetProfessionLabel(CustomParentChildPawn pawn) {
             if (!pawn.Hidden) {
-                return pawn.Pawn.ProfessionLabel;
+                return pawn.Pawn.ProfessionLabelShort;
             }
             if (pawn.Pawn.IsAdult && visibleBackstories.Contains(pawn.Pawn.Adulthood)) {
-                return pawn.Pawn.ProfessionLabel;
+                return pawn.Pawn.ProfessionLabelShort;
             }
             else if (!pawn.Pawn.IsAdult && visibleBackstories.Contains(pawn.Pawn.Childhood)) {
-                return pawn.Pawn.ProfessionLabel;
+                return pawn.Pawn.ProfessionLabelShort;
             }
             else {
                 return "Unknown";


### PR DESCRIPTION
- Split the `CustomPawn.ProfessionLabel` property into long and short versions, `ProfessionLabel` and `ProfessionLabelShort`
- Changed the relationship pawn tooltip to use the long profession instead of the short one.