### PR TITLE
Added warning for more than three traits

### DIFF
--- a/Resources/Languages/English/Keyed/EdBPrepareCarefully.xml
+++ b/Resources/Languages/English/Keyed/EdBPrepareCarefully.xml
@@ -126,7 +126,7 @@
     Disable point limits to prepare your starting colonists with no limitations.
   </EdB.PC.Page.Points.UsePoints.Tip>
   <EdB.PC.Page.Title>Prepare Carefully</EdB.PC.Page.Title>
-
+  
   <EdB.PC.Panel.Age.Biological>Biological Age</EdB.PC.Panel.Age.Biological>
   <EdB.PC.Panel.Age.Chronological>Chronological Age</EdB.PC.Panel.Age.Chronological>
 
@@ -184,6 +184,7 @@ You can play the game with your colonists as they are, but you may see an error 
   
   <EdB.PC.Panel.Traits.None>No traits</EdB.PC.Panel.Traits.None>
   <EdB.PC.Panel.Traits.Title>Traits</EdB.PC.Panel.Traits.Title>
+  <EdB.PC.Panel.Traits.Warning.TooManyTraits>Normally, only a maximum of three traits are allowed per character.  You can add more here, but those traits may not be displayed properly in all of the character info screens in the game.</EdB.PC.Panel.Traits.Warning.TooManyTraits>
 
   <EdB.PC.TabView.Animals.Title>Animals</EdB.PC.TabView.Animals.Title>
   <EdB.PC.TabView.Equipment.Title>Equipment</EdB.PC.TabView.Equipment.Title>

--- a/Source/Constraints.cs
+++ b/Source/Constraints.cs
@@ -4,5 +4,7 @@ namespace EdB.PrepareCarefully {
         public static int AgeBiologicalMax = 99;
         public static int AgeBiologicalMin = 14;
         public static int AgeChronologicalMax = 3200;
+        public static int MaxVanillaTraits = 3;
+        public static int MaxTraits = 10;
     }
 }

--- a/Source/CostCalculator.cs
+++ b/Source/CostCalculator.cs
@@ -145,9 +145,13 @@ namespace EdB.PrepareCarefully {
             cost.marketValue += levelCost * passionLevelCount;
 
             // Calculate trait cost.
-            if (pawn.Traits.Count() > 3) {
-                double extraTraitCount = (double)(pawn.Traits.Count() - 3);
-                cost.marketValue += extraTraitCount * 75.0;
+            if (pawn.TraitCount > Constraints.MaxVanillaTraits) {
+                int extraTraitCount = pawn.TraitCount - Constraints.MaxVanillaTraits;
+                double extraTraitCost = 100;
+                for (int i=0; i< extraTraitCount; i++) {
+                    cost.marketValue += extraTraitCost;
+                    extraTraitCost = Math.Ceiling(extraTraitCost * 2.5);
+                }
             }
 
             // Calculate cost of worn apparel.

--- a/Source/CustomPawn.cs
+++ b/Source/CustomPawn.cs
@@ -936,6 +936,12 @@ namespace EdB.PrepareCarefully {
             }
         }
 
+        public int TraitCount {
+            get {
+                return this.Pawn.story.traits.allTraits.Count;
+            }
+        }
+
         protected void ResetTraits() {
             SyncBodyParts();
             UpdateSkillLevelsForNewBackstoryOrTrait();

--- a/Source/PanelBase.cs
+++ b/Source/PanelBase.cs
@@ -21,6 +21,10 @@ namespace EdB.PrepareCarefully {
                 return null;
             }
         }
+        public string Warning {
+            get;
+            set;
+        }
         public PanelBase() {
         }
 
@@ -52,12 +56,19 @@ namespace EdB.PrepareCarefully {
             if (PanelHeader == null) {
                 return;
             }
+            Rect labelRect = new Rect(15 + PanelRect.xMin, 5 + PanelRect.yMin, PanelRect.width - 30, 40);
+            if (!string.IsNullOrEmpty(Warning)) {
+                Rect alertRect = new Rect(8 + PanelRect.xMin, 9 + PanelRect.yMin, 20, 20);
+                GUI.DrawTexture(alertRect, Textures.TextureAlertSmall);
+                TooltipHandler.TipRegion(alertRect, Warning);
+                labelRect = labelRect.InsetBy(17, 0, 0, 0);
+            }
             var fontValue = Text.Font;
             var anchorValue = Text.Anchor;
             var colorValue = GUI.color;
             Text.Font = GameFont.Medium;
             Text.Anchor = TextAnchor.UpperLeft;
-            Widgets.Label(new Rect(15 + PanelRect.xMin, 5 + PanelRect.yMin, PanelRect.width - 30, 40), PanelHeader);
+            Widgets.Label(labelRect, PanelHeader);
             Text.Font = fontValue;
             Text.Anchor = anchorValue;
             GUI.color = colorValue;

--- a/Source/PanelIncapableOf.cs
+++ b/Source/PanelIncapableOf.cs
@@ -24,6 +24,21 @@ namespace EdB.PrepareCarefully {
             RectText = new Rect(panelPadding.x, BodyRect.y, textWidth, textHeight);
         }
         protected override void DrawPanelContent(State state) {
+            if (state.MissingWorkTypes != null) {
+                if (cachedMissingWorkTypes != state.MissingWorkTypes) {
+                    cachedMissingWorkTypes = state.MissingWorkTypes;
+                    missingWorkTypeString = "";
+                    foreach (var type in state.MissingWorkTypes) {
+                        missingWorkTypeString += "EdB.PC.Panel.Incapable.WarningItem".Translate(new object[] { type }) + "\n";
+                    }
+                    missingWorkTypeString = missingWorkTypeString.TrimEndNewlines();
+                }
+                Warning = "EdB.PC.Panel.Incapable.Warning".Translate(new object[] { missingWorkTypeString });
+            }
+            else {
+                Warning = null;
+            }
+
             base.DrawPanelContent(state);
 
             GUI.color = Style.ColorText;
@@ -38,20 +53,6 @@ namespace EdB.PrepareCarefully {
             Text.Font = GameFont.Small;
             Widgets.Label(RectText, incapable);
 
-            if (state.MissingWorkTypes != null) {
-                GUI.color = Color.white;
-                Rect alertRect = new Rect(PanelRect.width - SizeAlert.x - 12, 10, SizeAlert.x, SizeAlert.y);
-                GUI.DrawTexture(alertRect, Textures.TextureAlertSmall);
-                if (cachedMissingWorkTypes != state.MissingWorkTypes) {
-                    cachedMissingWorkTypes = state.MissingWorkTypes;
-                    missingWorkTypeString = "";
-                    foreach (var type in state.MissingWorkTypes) {
-                        missingWorkTypeString += "EdB.PC.Panel.Incapable.WarningItem".Translate(new object[] { type }) + "\n";
-                    }
-                    missingWorkTypeString = missingWorkTypeString.TrimEndNewlines();
-                }
-                TooltipHandler.TipRegion(alertRect, "EdB.PC.Panel.Incapable.Warning".Translate(new object[] { missingWorkTypeString }));
-            }
         }
     }
 }

--- a/Source/PanelTraits.cs
+++ b/Source/PanelTraits.cs
@@ -51,14 +51,20 @@ namespace EdB.PrepareCarefully {
         }
 
         protected override void DrawPanelContent(State state) {
+            CustomPawn currentPawn = state.CurrentPawn;
+            if (currentPawn.TraitCount > Constraints.MaxVanillaTraits) {
+                Warning = "EdB.PC.Panel.Traits.Warning.TooManyTraits".Translate();
+            }
+            else {
+                Warning = null;
+            }
             base.DrawPanelContent(state);
-            CustomPawn customPawn = state.CurrentPawn;
 
             float cursor = 0;
             GUI.color = Color.white;
             GUI.BeginGroup(RectScrollFrame);
             try {
-                if (customPawn.Traits.Count() == 0) {
+                if (currentPawn.Traits.Count() == 0) {
                     GUI.color = Style.ColorText;
                     Widgets.Label(RectScrollView.InsetBy(6, 0, 0, 0), "EdB.PC.Panel.Traits.None".Translate());
                 }
@@ -67,7 +73,7 @@ namespace EdB.PrepareCarefully {
                 scrollView.Begin(RectScrollView);
 
                 int index = 0;
-                foreach (Trait trait in customPawn.Traits) {
+                foreach (Trait trait in currentPawn.Traits) {
                     if (index >= fields.Count) {
                         fields.Add(new Field());
                     }
@@ -89,7 +95,7 @@ namespace EdB.PrepareCarefully {
 
                     if (trait != null) {
                         field.Label = trait.LabelCap;
-                        field.Tip = trait.TipString(customPawn.Pawn);
+                        field.Tip = trait.TipString(currentPawn.Pawn);
                     }
                     else {
                         field.Label = null;
@@ -105,7 +111,7 @@ namespace EdB.PrepareCarefully {
                                 return t.LabelCap;
                             },
                             DescriptionFunc = (Trait t) => {
-                                return t.TipString(customPawn.Pawn);
+                                return t.TipString(currentPawn.Pawn);
                             },
                             SelectedFunc = (Trait t) => {
                                 if ((selectedTrait == null || t == null) && selectedTrait != t) {
@@ -120,7 +126,7 @@ namespace EdB.PrepareCarefully {
                                 if (t == null) {
                                     return originalTrait != null;
                                 }
-                                else if ((originalTrait == null || !originalTrait.Label.Equals(t.Label)) && customPawn.HasTrait(t)) {
+                                else if ((originalTrait == null || !originalTrait.Label.Equals(t.Label)) && currentPawn.HasTrait(t)) {
                                     return false;
                                 }
                                 else {
@@ -140,10 +146,10 @@ namespace EdB.PrepareCarefully {
                         Find.WindowStack.Add(dialog);
                     };
                     field.PreviousAction = () => {
-                        SelectPreviousTrait(customPawn, index);
+                        SelectPreviousTrait(currentPawn, index);
                     };
                     field.NextAction = () => {
-                        SelectNextTrait(customPawn, index);
+                        SelectNextTrait(currentPawn, index);
                     };
                     field.Draw();
 
@@ -191,7 +197,8 @@ namespace EdB.PrepareCarefully {
             // Add trait button.
             Rect addRect = new Rect(randomizeRect.x - 24, 12, 16, 16);
             Style.SetGUIColorForButton(addRect);
-            bool addButtonEnabled = (state.CurrentPawn != null && state.CurrentPawn.Traits.Count() < 4);
+            int traitCount = state.CurrentPawn.Traits.Count();
+            bool addButtonEnabled = (state.CurrentPawn != null && traitCount < Constraints.MaxTraits);
             if (!addButtonEnabled) {
                 GUI.color = Style.ColorButtonDisabled;
             }
@@ -204,7 +211,7 @@ namespace EdB.PrepareCarefully {
                         return t.LabelCap;
                     },
                     DescriptionFunc = (Trait t) => {
-                        return t.TipString(customPawn.Pawn);
+                        return t.TipString(currentPawn.Pawn);
                     },
                     SelectedFunc = (Trait t) => {
                         return selectedTrait == t;
@@ -213,7 +220,7 @@ namespace EdB.PrepareCarefully {
                         selectedTrait = t;
                     },
                     EnabledFunc = (Trait t) => {
-                        if (customPawn.HasTrait(t)) {
+                        if (currentPawn.HasTrait(t)) {
                             return false;
                         }
                         else {


### PR DESCRIPTION
- Added an alert/warning for when the user adds more than three traits to a character.
- Changed the visual treatment of the alert in the "Incapable Of" panel to match the new one in the "Traits" panel.
- Cost calculator changes for more than four traits.