### PR TITLE
Expect translated text in the options dialog

### DIFF
--- a/Source/Dialog_Options.cs
+++ b/Source/Dialog_Options.cs
@@ -36,7 +36,7 @@ namespace EdB.PrepareCarefully {
                 ComputeSizes();
             }
         }
-        public string ConfirmButtonLabel = "EdB.PC.Common.Close";
+        public string ConfirmButtonLabel = "EdB.PC.Common.Close".Translate();
 
         public string CancelButtonLabel = null;
 
@@ -123,7 +123,7 @@ namespace EdB.PrepareCarefully {
             GUI.color = Color.white;
             if (HeaderLabel != null) {
                 Text.Font = GameFont.Medium;
-                Widgets.Label(HeaderRect, HeaderLabel.Translate());
+                Widgets.Label(HeaderRect, HeaderLabel);
             }
 
             Text.Font = GameFont.Small;
@@ -195,12 +195,12 @@ namespace EdB.PrepareCarefully {
             GUI.BeginGroup(FooterRect);
             Rect buttonRect = SingleButtonRect;
             if (CancelButtonLabel != null) {
-                if (Widgets.ButtonText(CancelButtonRect, CancelButtonLabel.Translate(), true, true, true)) {
+                if (Widgets.ButtonText(CancelButtonRect, CancelButtonLabel, true, true, true)) {
                     this.Close(true);
                 }
                 buttonRect = ConfirmButtonRect;
             }
-            if (Widgets.ButtonText(buttonRect, ConfirmButtonLabel.Translate(), true, true, true)) {
+            if (Widgets.ButtonText(buttonRect, ConfirmButtonLabel, true, true, true)) {
                 string validationMessage = ConfirmValidation();
                 if (validationMessage != null) {
                     Messages.Message(validationMessage.Translate(), MessageSound.RejectInput);

--- a/Source/PanelHealth.cs
+++ b/Source/PanelHealth.cs
@@ -217,9 +217,9 @@ namespace EdB.PrepareCarefully {
                 };
 
                 severityDialog = new Dialog_Options<InjurySeverity>(severityOptions) {
-                    ConfirmButtonLabel = "EdB.PC.Common.Add",
-                    CancelButtonLabel = "EdB.PC.Common.Cancel",
-                    HeaderLabel = "EdB.PC.Panel.Health.SelectSeverity",
+                    ConfirmButtonLabel = "EdB.PC.Common.Add".Translate(),
+                    CancelButtonLabel = "EdB.PC.Common.Cancel".Translate(),
+                    HeaderLabel = "EdB.PC.Panel.Health.SelectSeverity".Translate(),
                     NameFunc = (InjurySeverity option) => {
                         if (!string.IsNullOrEmpty(option.Label)) {
                             return option.Label;
@@ -248,9 +248,9 @@ namespace EdB.PrepareCarefully {
                 };
 
                 bodyPartDialog = new Dialog_Options<BodyPartRecord>(null) {
-                    ConfirmButtonLabel = "EdB.PC.Common.Add",
-                    CancelButtonLabel = "EdB.PC.Common.Cancel",
-                    HeaderLabel = "EdB.PC.Dialog.BodyPart.Header",
+                    ConfirmButtonLabel = "EdB.PC.Common.Add".Translate(),
+                    CancelButtonLabel = "EdB.PC.Common.Cancel".Translate(),
+                    HeaderLabel = "EdB.PC.Dialog.BodyPart.Header".Translate(),
                     NameFunc = (BodyPartRecord option) => {
                         return option.def.LabelCap;
                     },
@@ -290,9 +290,9 @@ namespace EdB.PrepareCarefully {
                 };
 
                 injuryOptionDialog = new Dialog_Options<InjuryOption>(PrepareCarefully.Instance.HealthManager.InjuryManager.Options) {
-                    ConfirmButtonLabel = "EdB.PC.Common.Next",
-                    CancelButtonLabel = "EdB.PC.Common.Cancel",
-                    HeaderLabel = "EdB.PC.Dialog.Injury.Header",
+                    ConfirmButtonLabel = "EdB.PC.Common.Next".Translate(),
+                    CancelButtonLabel = "EdB.PC.Common.Cancel".Translate(),
+                    HeaderLabel = "EdB.PC.Dialog.Injury.Header".Translate(),
                     NameFunc = (InjuryOption option) => {
                         return option.Label;
                     },
@@ -339,9 +339,9 @@ namespace EdB.PrepareCarefully {
                 };
 
                 implantRecipeDialog = new Dialog_Options<RecipeDef>(PrepareCarefully.Instance.HealthManager.ImplantManager.RecipesForPawn(customPawn)) {
-                    ConfirmButtonLabel = "EdB.PC.Common.Next",
-                    CancelButtonLabel = "EdB.PC.Common.Cancel",
-                    HeaderLabel = "EdB.PC.Dialog.Implant.Header",
+                    ConfirmButtonLabel = "EdB.PC.Common.Next".Translate(),
+                    CancelButtonLabel = "EdB.PC.Common.Cancel".Translate(),
+                    HeaderLabel = "EdB.PC.Dialog.Implant.Header".Translate(),
                     NameFunc = (RecipeDef recipe) => {
                         return recipe.LabelCap;
                     },
@@ -388,8 +388,8 @@ namespace EdB.PrepareCarefully {
                 };
 
                 hediffTypeDialog = new Dialog_Options<string>(new string[] { HediffTypeInjury, HediffTypeImplant }) {
-                    ConfirmButtonLabel = "EdB.PC.Common.Next",
-                    CancelButtonLabel = "EdB.PC.Common.Cancel",
+                    ConfirmButtonLabel = "EdB.PC.Common.Next".Translate(),
+                    CancelButtonLabel = "EdB.PC.Common.Cancel".Translate(),
                     NameFunc = (string type) => {
                         return ("EdB.PC.Panel.Health." + type).Translate();
                     },

--- a/Source/PanelPawnList.cs
+++ b/Source/PanelPawnList.cs
@@ -216,8 +216,8 @@ namespace EdB.PrepareCarefully {
         protected void OpenAddPawnDialog() {
             FactionDef selectedFaction = Faction.OfPlayer.def;
             var dialog = new Dialog_Options<FactionDef>(providerFactions.Factions) {
-                ConfirmButtonLabel = "EdB.PC.Common.Add",
-                CancelButtonLabel = "EdB.PC.Common.Cancel",
+                ConfirmButtonLabel = "EdB.PC.Common.Add".Translate(),
+                CancelButtonLabel = "EdB.PC.Common.Cancel".Translate(),
                 HeaderLabel = "EdB.PC.Panel.PawnList.SelectFaction".Translate(),
                 NameFunc = (FactionDef def) => {
                     return def.LabelCap;

--- a/Source/PanelRelationshipsOther.cs
+++ b/Source/PanelRelationshipsOther.cs
@@ -231,9 +231,9 @@ namespace EdB.PrepareCarefully {
 
             Dialog_Options<PawnRelationDef> relationshipDialog =
                 new Dialog_Options<PawnRelationDef>(null) {
-                    ConfirmButtonLabel = "EdB.PC.Common.Next",
-                    CancelButtonLabel = "EdB.PC.Common.Cancel",
-                    HeaderLabel = "EdB.PC.AddRelationship.Header.Relationship",
+                    ConfirmButtonLabel = "EdB.PC.Common.Next".Translate(),
+                    CancelButtonLabel = "EdB.PC.Common.Cancel".Translate(),
+                    HeaderLabel = "EdB.PC.AddRelationship.Header.Relationship".Translate(),
                     NameFunc = (PawnRelationDef def) => {
                         return def.GetGenderSpecificLabelCap(sourcePawn.Pawn);
                     },

--- a/Source/PanelTraits.cs
+++ b/Source/PanelTraits.cs
@@ -202,6 +202,7 @@ namespace EdB.PrepareCarefully {
                 SoundDefOf.TickLow.PlayOneShotOnCamera();
                 Trait selectedTrait = null;
                 Dialog_Options<Trait> dialog = new Dialog_Options<Trait>(providerTraits.Traits) {
+                    ConfirmButtonLabel = "EdB.PC.Common.Add".Translate(),
                     NameFunc = (Trait t) => {
                         return t.LabelCap;
                     },


### PR DESCRIPTION
Updated the options dialog to expect aleady-translated text for header and button labels.