### PR TITLE
Refactor injury/implant initialization for new pawns

### DIFF
--- a/Source/BodyPartDictionary.cs
+++ b/Source/BodyPartDictionary.cs
@@ -121,7 +121,7 @@ namespace EdB.PrepareCarefully {
                 return a.LabelCap.CompareTo(b.LabelCap);
             });
 
-            // Classify body parts into all, outside and skin-covered lists.
+            // Classify body parts into three separate lists: all, outside and skin-covered.
             foreach (BodyPartRecord record in bodyDef.AllParts) {
                 allBodyParts.Add(record);
                 if (record.depth == BodyPartDepth.Outside) {

--- a/Source/ControllerPawns.cs
+++ b/Source/ControllerPawns.cs
@@ -160,17 +160,9 @@ namespace EdB.PrepareCarefully {
         }
         public void AddFactionPawn(FactionDef def) {
             var kinds = DefDatabase<PawnKindDef>.AllDefs.Where((PawnKindDef arg) => {
-                return (arg.defaultFactionType == def);
+                return (arg.defaultFactionType != null && arg.defaultFactionType.LabelCap == def.LabelCap);
             });
-            PawnKindDef kindDef = null;
-            int count = kinds.Count();
-            if (count > 0) {
-                int index = randomizer.Random.Next(count);
-                kindDef = kinds.ElementAt(index);
-            }
-            else if (def.basicMemberKind != null) {
-                kindDef = def.basicMemberKind;
-            }
+            PawnKindDef kindDef = kinds.RandomElementWithFallback(def.basicMemberKind);
             Faction faction = Faction.OfPlayer;
             if (def != Faction.OfPlayer.def) {
                 faction = new Faction() {
@@ -182,18 +174,18 @@ namespace EdB.PrepareCarefully {
                 rel.hostile = false;
                 (typeof(Faction).GetField("relations", BindingFlags.Instance | BindingFlags.NonPublic)
                     .GetValue(faction) as List<FactionRelation>).Add(rel);
-                
             }
-            CustomPawn pawn = new CustomPawn(randomizer.GeneratePawn(new PawnGenerationRequestWrapper() {
+            Pawn pawn = randomizer.GeneratePawn(new PawnGenerationRequestWrapper() {
                 Faction = faction,
                 KindDef = kindDef,
                 Context = PawnGenerationContext.NonPlayer
-            }.Request));
-            
-            pawn.Pawn.SetFactionDirect(Faction.OfPlayer);
-            PrepareCarefully.Instance.AddPawn(pawn);
+            }.Request);
+            CustomPawn customPawn = new CustomPawn(pawn);
+
+            customPawn.Pawn.SetFactionDirect(Faction.OfPlayer);
+            PrepareCarefully.Instance.AddPawn(customPawn);
             state.CurrentPawnIndex = PrepareCarefully.Instance.Pawns.Count - 1;
-            PawnAdded(pawn);
+            PawnAdded(customPawn);
         }
 
         // Gender-related actions.

--- a/Source/ImplantManager.cs
+++ b/Source/ImplantManager.cs
@@ -45,7 +45,7 @@ namespace EdB.PrepareCarefully {
             BodyPartDictionary dictionary = GetBodyPartDictionary(pawn.def);
             return dictionary.FindReplaceableBodyPartByName(name);
         }
-
+        
     }
 }
 

--- a/Source/InjuryManager.cs
+++ b/Source/InjuryManager.cs
@@ -17,26 +17,6 @@ namespace EdB.PrepareCarefully {
             }
         }
 
-        public void InitializePawnInjuries(Pawn pawn, CustomPawn customPawn) {
-            foreach (var x in pawn.health.hediffSet.hediffs) {
-                InjuryOption option = FindOptionByHediffDef(x.def);
-                if (option != null) {
-                    Injury injury = new Injury();
-                    injury.BodyPartRecord = x.Part;
-                    injury.Option = option;
-                    injury.Severity = x.Severity;
-                    HediffComp_GetsOld getsOld = x.TryGetComp<HediffComp_GetsOld>();
-                    if (getsOld != null) {
-                        injury.PainFactor = getsOld.painFactor;
-                    }
-                    customPawn.AddInjury(injury);
-                }
-                else {
-                    Log.Warning("Could not find injury option for hediff: " + x.def);
-                }
-            }
-        }
-
         public InjuryOption FindOptionByHediffDef(HediffDef def) {
             foreach (InjuryOption o in Options) {
                 if (o.HediffDef == def) {

--- a/Source/PrepareCarefully.cs
+++ b/Source/PrepareCarefully.cs
@@ -509,7 +509,6 @@ namespace EdB.PrepareCarefully {
                 customPawnToOriginalPawnMap.Add(customPawn, originalPawn);
                 originalPawnToCustomPawnMap.Add(originalPawn, customPawn);
                 this.pawns.Add(customPawn);
-                healthManager.InjuryManager.InitializePawnInjuries(originalPawn, customPawn);
             }
         }
 


### PR DESCRIPTION
- Moved pawn hediff initialization code from InjuryManager into CustomPawn.
- Added implant initialization code for new pawns.
Also:
- Includes fix so that passions are not assigned to disabled skills.
- Includes fix so that random pawn kind selection for faction pawns does not exclude factions whose names are not unique (i.e. Spacers)