### PR TITLE
Bugfixes for 0.17.1.1

### DIFF
--- a/EdBPrepareCarefully.csproj
+++ b/EdBPrepareCarefully.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>EdB.PrepareCarefully</RootNamespace>
     <AssemblyName>EdBPrepareCarefully</AssemblyName>
-    <ReleaseVersion>0.17.0.4</ReleaseVersion>
+    <ReleaseVersion>0.17.1.1</ReleaseVersion>
     <UseMSBuildEngine>False</UseMSBuildEngine>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
   </PropertyGroup>
@@ -81,6 +81,7 @@
     <Compile Include="Source\PresetSaver.cs" />
     <Compile Include="Source\ProviderHeadType.cs" />
     <Compile Include="Source\Providers.cs" />
+    <Compile Include="Source\RaceHeadTypes.cs" />
     <Compile Include="Source\Randomizer.cs" />
     <Compile Include="Source\RelatedPawn.cs" />
     <Compile Include="Source\RelationshipBuilder.cs" />
@@ -172,7 +173,9 @@
   <ItemGroup />
   <ItemGroup>
     <None Include="Resources\CHANGELOG.txt" />
-    <None Include="Resources\About\About.xml" />
+    <None Include="Resources\About\About.xml">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="Resources\Languages\English\Keyed\EdBPrepareCarefully.xml" />
     <None Include="Resources\Textures\EdB\PrepareCarefully\ButtonDelete.png" />
     <None Include="Resources\Textures\EdB\PrepareCarefully\ButtonNext.png" />

--- a/EdBPrepareCarefully.sln
+++ b/EdBPrepareCarefully.sln
@@ -197,6 +197,6 @@ Global
 		$29.IncludeStaticEntities = True
 		$0.VersionControlPolicy = $31
 		$31.inheritsSet = Mono
-		version = 0.17.0.4
+		version = 0.17.1.1
 	EndGlobalSection
 EndGlobal

--- a/Resources/About/About.xml
+++ b/Resources/About/About.xml
@@ -8,6 +8,6 @@
 
 If you get a set of starting colonists that you like, save them as a preset so that you can start your game the same way next time.
 
-[Version 0.17.0.4]
+[Version 0.17.1.1]
 	</description>
 </ModMetaData>

--- a/Source/ControllerPawns.cs
+++ b/Source/ControllerPawns.cs
@@ -180,6 +180,8 @@ namespace EdB.PrepareCarefully {
                 KindDef = kindDef,
                 Context = PawnGenerationContext.NonPlayer
             }.Request);
+            pawn.equipment.DestroyAllEquipment(DestroyMode.Vanish);
+            pawn.inventory.DestroyAll(DestroyMode.Vanish);
             CustomPawn customPawn = new CustomPawn(pawn);
 
             customPawn.Pawn.SetFactionDirect(Faction.OfPlayer);

--- a/Source/CustomParentChildPawn.cs
+++ b/Source/CustomParentChildPawn.cs
@@ -71,6 +71,16 @@ namespace EdB.PrepareCarefully {
                 name = value;
             }
         }
+        public string FullName {
+            get {
+                if (hidden) {
+                    return Name;
+                }
+                else {
+                    return pawn.Pawn.Name.ToStringFull;
+                }
+            }
+        }
         public CustomParentChildPawn() {
             this.pawn = null;
             this.hidden = false;

--- a/Source/PanelAppearance.cs
+++ b/Source/PanelAppearance.cs
@@ -151,6 +151,11 @@ namespace EdB.PrepareCarefully {
                 }
             }
 
+            // Get material definitions so that we can use them for sorting later.
+            ThingDef synthreadDef = DefDatabase<ThingDef>.GetNamedSilentFail("Synthread");
+            ThingDef devilstrandDef = DefDatabase<ThingDef>.GetNamedSilentFail("DevilstrandCloth");
+            ThingDef hyperweaveDef = DefDatabase<ThingDef>.GetNamedSilentFail("Hyperweave");
+
             // For each apparel def, get the list of all materials that can be used to make it.
             foreach (ThingDef thingDef in DefDatabase<ThingDef>.AllDefs) {
                 if (thingDef.apparel != null && thingDef.MadeFromStuff) {
@@ -164,6 +169,40 @@ namespace EdB.PrepareCarefully {
                                 }
                             }
                         }
+                        stuffList.Sort((ThingDef a, ThingDef b) => {
+                            if (a != b) {
+                                if (a == synthreadDef) {
+                                    return -1;
+                                }
+                                else if (b == synthreadDef) {
+                                    return 1;
+                                }
+                                else if (a == ThingDefOf.Cloth) {
+                                    return -1;
+                                }
+                                else if (b == ThingDefOf.Cloth) {
+                                    return 1;
+                                }
+                                else if (a == devilstrandDef) {
+                                    return -1;
+                                }
+                                else if (b == devilstrandDef) {
+                                    return 1;
+                                }
+                                else if (a == hyperweaveDef) {
+                                    return -1;
+                                }
+                                else if (b == hyperweaveDef) {
+                                    return 1;
+                                }
+                                else {
+                                    return a.LabelCap.CompareTo(b.LabelCap);
+                                }
+                            }
+                            else {
+                                return 0;
+                            }
+                        });
                         apparelStuffLookup[thingDef] = stuffList;
                     }
                 }
@@ -241,6 +280,10 @@ namespace EdB.PrepareCarefully {
                                 continue;
                             }
                         }
+                    }
+                    // Disable head type selection when no valid head type could be found for the pawn (i.e. headType is null).
+                    if (pawnLayer == PawnLayers.HeadType && customPawn.HeadType == null) {
+                        continue;
                     }
                     label = PawnLayers.Label(pawnLayers[i]);
                     list.Add(new FloatMenuOption(label, this.pawnLayerActions[i], MenuOptionPriority.Default, null, null, 0, null, null));
@@ -705,7 +748,7 @@ namespace EdB.PrepareCarefully {
         }
 
         protected void SelectNextHead(CustomPawn customPawn, int direction) {
-            List<HeadType> heads = PrepareCarefully.Instance.Providers.HeadType.GetHeadTypes(customPawn.Gender);
+            List<HeadType> heads = PrepareCarefully.Instance.Providers.HeadType.GetHeadTypes(customPawn.Pawn.def, customPawn.Gender);
             int index = heads.IndexOf(customPawn.HeadType);
             if (index == -1) {
                 return;
@@ -789,7 +832,7 @@ namespace EdB.PrepareCarefully {
         }
 
         protected void ShowHeadDialog(CustomPawn customPawn) {
-            List<HeadType> headTypes = PrepareCarefully.Instance.Providers.HeadType.GetHeadTypes(customPawn.Gender);
+            List<HeadType> headTypes = PrepareCarefully.Instance.Providers.HeadType.GetHeadTypes(customPawn.Pawn.def, customPawn.Gender);
             Dialog_Options<HeadType> dialog = new Dialog_Options<HeadType>(headTypes) {
                 NameFunc = (HeadType headType) => {
                     return headType.Label;

--- a/Source/PanelRelationshipsParentChild.cs
+++ b/Source/PanelRelationshipsParentChild.cs
@@ -314,7 +314,7 @@ namespace EdB.PrepareCarefully {
                     "EdB.PC.Pawn.HiddenPawnDescriptionWithGender".Translate(new object[] { profession, pawn.Gender.GetLabel() }) :
                     "EdB.PC.Pawn.HiddenPawnDescriptionNoGender".Translate(new object[] { profession });
             }
-            return pawn.Pawn.Name.ToStringFull + "\n" + description;
+            return parentChildPawn.FullName + "\n" + description;
         }
         protected List<WidgetTable<CustomParentChildPawn>.RowGroup> rowGroups = new List<WidgetTable<CustomParentChildPawn>.RowGroup>();
         protected void ShowParentDialogForGroup(CustomParentChildGroup group, CustomParentChildPawn selected, Action<CustomParentChildPawn> action) {

--- a/Source/RaceHeadTypes.cs
+++ b/Source/RaceHeadTypes.cs
@@ -1,0 +1,169 @@
+﻿using RimWorld;
+using System;
+using System.Collections.Generic;
+using System.Collections;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using UnityEngine;
+using Verse;
+using Verse.Sound;
+
+namespace EdB.PrepareCarefully {
+    public class RaceHeadTypes {
+        protected ThingDef race;
+        protected List<Graphic> heads = new List<Graphic>();
+        protected List<string> headPaths = new List<string>();
+        protected List<HeadType> maleHeadTypes = new List<HeadType>();
+        protected List<HeadType> femaleHeadTypes = new List<HeadType>();
+        protected List<HeadType> noGenderHeaderTypes = new List<HeadType>();
+        public Dictionary<string, HeadType> pathDictionary = new Dictionary<string, HeadType>();
+        public RaceHeadTypes(ThingDef race) {
+            this.race = race;
+            Initialize();
+        }
+        public List<HeadType> GetHeadTypes(Gender gender) {
+            if (gender == Gender.Male) {
+                return maleHeadTypes;
+            }
+            else if (gender == Gender.Female) {
+                return femaleHeadTypes;
+            }
+            else {
+                return noGenderHeaderTypes;
+            }
+        }
+        public HeadType FindHeadType(string graphicsPath) {
+            HeadType result;
+            if (pathDictionary.TryGetValue(graphicsPath, out result)) {
+                return result;
+            }
+            else {
+                return null;
+            }
+        }
+        public HeadType FindHeadTypeForGender(HeadType headType, Gender gender) {
+            if (headType.Gender == gender) {
+                return headType;
+            }
+            string graphicsPath = headType.GraphicPath;
+            if (gender == Gender.Male) {
+                graphicsPath = graphicsPath.Replace("Female", "Male");
+            }
+            else {
+                graphicsPath = graphicsPath.Replace("Male", "Female");
+            }
+            HeadType result = FindHeadType(graphicsPath);
+            return result != null ? result : headType;
+        }
+        protected void Initialize() {
+            MethodInfo headGraphicsMethod = typeof(GraphicDatabaseHeadRecords).GetMethod("BuildDatabaseIfNecessary", BindingFlags.Static | BindingFlags.NonPublic);
+            headGraphicsMethod.Invoke(null, null);
+            string[] headsFolderPaths = GetFolderPaths();
+            for (int i = 0; i < headsFolderPaths.Length; i++) {
+                string text = headsFolderPaths[i];
+                // TODO: Looks like this doesn't work for modded graphics.  Need to figure out how to get
+                // the list of heads from the mod directory.
+                IEnumerable<string> graphicsInFolder = GraphicDatabaseUtility.GraphicNamesInFolder(text);
+                if (graphicsInFolder.Count() == 0) {
+                    //Log.Message("No head graphics in folder: " + text);
+                }
+                foreach (string current in GraphicDatabaseUtility.GraphicNamesInFolder(text)) {
+                    //Log.Message("head in folder: " + current);
+                    string fullPath = text + "/" + current;
+                    HeadType headType = CreateHeadTypeFromGraphicPath(fullPath);
+                    if (headType.Gender == Gender.Male) {
+                        maleHeadTypes.Add(headType);
+                    }
+                    else if (headType.Gender == Gender.Female) {
+                        femaleHeadTypes.Add(headType);
+                    }
+                    else {
+                        noGenderHeaderTypes.Add(headType);
+                    }
+                    pathDictionary.Add(fullPath, headType);
+                }
+            }
+        }
+        protected HeadType CreateHeadTypeFromGraphicPath(string graphicPath) {
+            HeadType result = new HeadType();
+            result.GraphicPath = graphicPath;
+            string[] strArray = Path.GetFileNameWithoutExtension(graphicPath).Split('_');
+            try {
+                result.CrownType = (CrownType)ParseHelper.FromString(strArray[strArray.Length - 2], typeof(CrownType));
+                result.Gender = (Gender)ParseHelper.FromString(strArray[strArray.Length - 3], typeof(Gender));
+            }
+            catch (Exception ex) {
+                Log.Warning("Parse error with head graphic at " + graphicPath + ": " + ex.Message);
+                result.CrownType = CrownType.Undefined;
+                result.Gender = Gender.None;
+            }
+            return result;
+        }
+        protected string[] GetFolderPaths() {
+            if (race == ThingDefOf.Human) {
+                return GetHumanFolderPaths();
+            }
+            else {
+                // TODO: WIP. Evaluate where this Alien Races custom logic should go.
+                List<string> resultPathList = new List<string>();
+                FieldInfo alienRaceField = this.race.GetType().GetField("alienRace", BindingFlags.Public | BindingFlags.Instance);
+                //Log.Message(" alienRaceField " + (alienRaceField == null ? "is null" : "in not null"));
+                if (alienRaceField != null) {
+                    object alienRaceObject = alienRaceField.GetValue(race);
+                    if (alienRaceObject != null) {
+                        FieldInfo graphicPathsField = alienRaceObject.GetType().GetField("graphicPaths", BindingFlags.Public | BindingFlags.Instance);
+                        //Log.Message(" graphicPathsField " + (graphicPathsField == null ? "is null" : "in not null"));
+                        object graphicPathsObject = graphicPathsField.GetValue(alienRaceObject);
+                        if (graphicPathsObject != null) {
+                            System.Collections.ICollection graphicPathsList = graphicPathsObject as System.Collections.ICollection;
+                            if (graphicPathsList != null) {
+                                //Log.Message("List count: " + graphicPathsList.Count);
+                                if (graphicPathsList.Count > 0) {
+                                    foreach (object o in graphicPathsList) {
+                                        //Log.Message(o.GetType().FullName);
+                                        FieldInfo headField = o.GetType().GetField("head", BindingFlags.Public | BindingFlags.Instance);
+                                        if (headField != null) {
+                                            object headsObject = headField.GetValue(o);
+                                            if (headsObject != null) {
+                                                string headPath = headsObject as string;
+                                                if (headPath != null) {
+                                                    headPath = headPath.Trim('/');
+                                                    resultPathList.Add(headPath);
+                                                    //Log.Message("headPath: " + headPath);
+                                                }
+                                                else {
+                                                    //Log.Message("headPath is not a string");
+                                                }
+                                            }
+                                            else {
+                                                //Log.Message("headsObject is null");
+                                            }
+                                        }
+                                        else {
+                                            //Log.Message("headField is null");
+                                        }
+                                    }
+                                }
+                            }
+                            else {
+                                //Log.Message("graphicPathsList is null");
+                            }
+                        }
+                    }
+                    else {
+                        //Log.Message("alienRaceObject is null");
+                    }
+                }
+                return resultPathList.ToArray();
+            }
+        }
+        protected string[] GetHumanFolderPaths() {
+            return new string[] {
+                "Things/Pawn/Humanlike/Heads/Male",
+                "Things/Pawn/Humanlike/Heads/Female"
+            };
+        }
+    }
+}

--- a/Source/Version3/ColonistLoaderVersion3.cs
+++ b/Source/Version3/ColonistLoaderVersion3.cs
@@ -52,6 +52,12 @@ namespace EdB.PrepareCarefully {
             PresetLoaderVersion3 loader = new PresetLoaderVersion3();
             CustomPawn loadedPawn = loader.LoadPawn(pawnRecord);
             if (loadedPawn != null) {
+                CustomPawn idConflictPawn = PrepareCarefully.Instance.Pawns.FirstOrDefault((CustomPawn p) => {
+                    return p.Id == loadedPawn.Id;
+                });
+                if (idConflictPawn != null) {
+                    loadedPawn.Id = Guid.NewGuid().ToString();
+                }
                 return loadedPawn;
             }
             if (loader.Failed) {


### PR DESCRIPTION
- Incremented version number to 0.17.1.1.
- Started support for alien races framework compatibility by splitting out the head type provider to support a separate set of head types per race.
   - Doesn't actually work yet, but it's a step forward.
   - Disabling head type selection for pawns that have unrecognized head graphics.
- Fixed problem where the name was visible for hidden pawns in a tooltip in the relationships tab view.
- Sorted apparel materials almost alphabetically.
- Assigning a new ID to a loaded character if its ID conflicts with that of another pawn.