### PR TITLE
Faction pawn fixes

### DIFF
--- a/Source/ControllerPawns.cs
+++ b/Source/ControllerPawns.cs
@@ -168,18 +168,7 @@ namespace EdB.PrepareCarefully {
                 return (arg.defaultFactionType != null && arg.defaultFactionType.LabelCap == def.LabelCap);
             });
             PawnKindDef kindDef = kinds.RandomElementWithFallback(def.basicMemberKind);
-            Faction faction = Faction.OfPlayer;
-            if (def != Faction.OfPlayer.def) {
-                faction = new Faction() {
-                    def = def
-                };
-                FactionRelation rel = new FactionRelation();
-                rel.other = Faction.OfPlayer;
-                rel.goodwill = 50;
-                rel.hostile = false;
-                (typeof(Faction).GetField("relations", BindingFlags.Instance | BindingFlags.NonPublic)
-                    .GetValue(faction) as List<FactionRelation>).Add(rel);
-            }
+            Faction faction = PrepareCarefully.Instance.Providers.Factions.GetFaction(def);
             Pawn pawn = randomizer.GeneratePawn(new PawnGenerationRequestWrapper() {
                 Faction = faction,
                 KindDef = kindDef,

--- a/Source/PanelPawnList.cs
+++ b/Source/PanelPawnList.cs
@@ -29,7 +29,6 @@ namespace EdB.PrepareCarefully {
         protected Rect RectButtonDelete;
         protected float SizeEntrySpacing = 4;
         protected ScrollViewVertical scrollView = new ScrollViewVertical();
-        protected ProviderFactions providerFactions = new ProviderFactions();
         protected FactionDef previousFaction = null;
 
         protected float shorterNameWidth = 0;
@@ -215,8 +214,9 @@ namespace EdB.PrepareCarefully {
         }
 
         protected void OpenAddPawnDialog() {
-            FactionDef selectedFaction = previousFaction != null ? previousFaction : providerFactions.NonPlayerHumanlikeFactionDefs.First();
-            var dialog = new Dialog_Options<FactionDef>(providerFactions.NonPlayerHumanlikeFactionDefs) {
+            ProviderFactions factionProvider = PrepareCarefully.Instance.Providers.Factions;
+            FactionDef selectedFaction = previousFaction != null ? previousFaction : factionProvider.NonPlayerHumanlikeFactionDefs.First();
+            var dialog = new Dialog_Options<FactionDef>(factionProvider.NonPlayerHumanlikeFactionDefs) {
                 ConfirmButtonLabel = "EdB.PC.Common.Add".Translate(),
                 CancelButtonLabel = "EdB.PC.Common.Cancel".Translate(),
                 HeaderLabel = "EdB.PC.Panel.PawnList.SelectFaction".Translate(),

--- a/Source/PrepareCarefully.cs
+++ b/Source/PrepareCarefully.cs
@@ -136,6 +136,7 @@ namespace EdB.PrepareCarefully {
 
         protected void InitializeProviders() {
             Providers.HeadType = new ProviderHeadType();
+            Providers.Factions = new ProviderFactions();
         }
 
         // TODO: Alpha 14

--- a/Source/Providers.cs
+++ b/Source/Providers.cs
@@ -8,5 +8,8 @@ namespace EdB.PrepareCarefully {
         public ProviderHeadType HeadType {
             get; set;
         }
+        public ProviderFactions Factions {
+            get; set;
+        }
     }
 }

--- a/Source/Randomizer.cs
+++ b/Source/Randomizer.cs
@@ -40,8 +40,7 @@ namespace EdB.PrepareCarefully {
             Faction faction = PrepareCarefully.Instance.Providers.Factions.GetFaction(factionDef);
             PawnGenerationRequest req = new PawnGenerationRequestWrapper() {
                 Faction = faction,
-                KindDef = kindDef,
-                Context = faction == Faction.OfPlayer ? PawnGenerationContext.PlayerStarter : PawnGenerationContext.NonPlayer
+                KindDef = kindDef
             }.Request;
             Pawn result = PawnGenerator.GeneratePawn(req);
             return result;
@@ -56,8 +55,7 @@ namespace EdB.PrepareCarefully {
             PawnGenerationRequest req = new PawnGenerationRequestWrapper() {
                 Faction = faction,
                 KindDef = kindDef,
-                FixedGender = gender,
-                Context = faction == Faction.OfPlayer ? PawnGenerationContext.PlayerStarter : PawnGenerationContext.NonPlayer
+                FixedGender = gender
             }.Request;
             Pawn result = PawnGenerator.GeneratePawn(req);
             return result;

--- a/Source/Randomizer.cs
+++ b/Source/Randomizer.cs
@@ -32,86 +32,64 @@ namespace EdB.PrepareCarefully {
             return result;
         }
 
-        public Pawn GenerateNpcKindOfColonist(PawnKindDef kindDef) {
+        public Pawn GenerateKindOfPawn(PawnKindDef kindDef) {
+            FactionDef factionDef = kindDef.defaultFactionType;
+            if (factionDef == null) {
+                factionDef = Faction.OfPlayer.def;
+            }
+            Faction faction = PrepareCarefully.Instance.Providers.Factions.GetFaction(factionDef);
             PawnGenerationRequest req = new PawnGenerationRequestWrapper() {
+                Faction = faction,
                 KindDef = kindDef,
-                Context = PawnGenerationContext.NonPlayer
+                Context = faction == Faction.OfPlayer ? PawnGenerationContext.PlayerStarter : PawnGenerationContext.NonPlayer
             }.Request;
             Pawn result = PawnGenerator.GeneratePawn(req);
             return result;
         }
 
-        public Pawn GenerateSameKindOfColonist(CustomPawn pawn) {
-            return GenerateKindOfColonist(pawn.Pawn.kindDef);
+        public Pawn GenerateKindAndGenderOfPawn(PawnKindDef kindDef, Gender gender) {
+            FactionDef factionDef = kindDef.defaultFactionType;
+            if (factionDef == null) {
+                factionDef = Faction.OfPlayer.def;
+            }
+            Faction faction = PrepareCarefully.Instance.Providers.Factions.GetFaction(factionDef);
+            PawnGenerationRequest req = new PawnGenerationRequestWrapper() {
+                Faction = faction,
+                KindDef = kindDef,
+                FixedGender = gender,
+                Context = faction == Faction.OfPlayer ? PawnGenerationContext.PlayerStarter : PawnGenerationContext.NonPlayer
+            }.Request;
+            Pawn result = PawnGenerator.GeneratePawn(req);
+            return result;
         }
 
-        public Pawn GenerateSameKindOfColonist(Pawn pawn) {
-            return GenerateKindOfColonist(pawn.kindDef);
+        public Pawn GenerateSameKindAndGenderOfPawn(CustomPawn customPawn) {
+            return GenerateKindAndGenderOfPawn(customPawn.Pawn.kindDef, customPawn.Gender);
         }
 
-        public void RandomizeAll(CustomPawn customPawn) {
-            Pawn pawn = GenerateSameKindOfColonist(customPawn);
-            customPawn.InitializeWithPawn(pawn);
+        public Pawn GenerateSameKindOfPawn(CustomPawn customPawn) {
+            return GenerateKindOfPawn(customPawn.Pawn.kindDef);
         }
 
-        public void RandomizeBackstory(CustomPawn customPawn) {
-            MethodInfo method = typeof(PawnBioAndNameGenerator).GetMethod("SetBackstoryInSlot", BindingFlags.Static | BindingFlags.NonPublic);
-            object[] arguments = new object[] { customPawn.Pawn, BackstorySlot.Childhood, null, Faction.OfPlayer.def };
-            method.Invoke(null, arguments);
-            customPawn.Childhood = arguments[2] as Backstory;
-            arguments = new object[] { customPawn.Pawn, BackstorySlot.Adulthood, null, Faction.OfPlayer.def };
-            method.Invoke(null, arguments);
-            customPawn.Adulthood = arguments[2] as Backstory;
+        public Pawn GenerateSameKindOfPawn(Pawn pawn) {
+            return GenerateKindOfPawn(pawn.kindDef);
         }
 
         public static Backstory RandomAdulthood(CustomPawn customPawn) {
+            PawnKindDef kindDef = customPawn.Pawn.kindDef;
+            FactionDef factionDef = kindDef.defaultFactionType;
+            if (factionDef == null) {
+                factionDef = Faction.OfPlayer.def;
+            }
             MethodInfo method = typeof(PawnBioAndNameGenerator).GetMethod("SetBackstoryInSlot", BindingFlags.Static | BindingFlags.NonPublic);
-            object[] arguments = new object[] { customPawn.Pawn, BackstorySlot.Adulthood, null, Faction.OfPlayer.def };
+            object[] arguments = new object[] { customPawn.Pawn, BackstorySlot.Adulthood, null, factionDef };
             method.Invoke(null, arguments);
             Backstory result = arguments[2] as Backstory;
             return result;
         }
 
-        public void RandomizeTraits(CustomPawn customPawn) {
-            Pawn pawn = GenerateSameKindOfColonist(customPawn);
-            List<Trait> traits = pawn.story.traits.allTraits;
-            customPawn.ClearTraits();
-            foreach (var trait in traits) {
-                customPawn.AddTrait(trait);
-            }
-        }
-
-        public void RandomizeAppearance(CustomPawn customPawn) {
-            Pawn pawn;
-            int tries = 0;
-            do {
-                pawn = GenerateSameKindOfColonist(customPawn);
-                tries++;
-            }
-            while (pawn.gender != customPawn.Gender && tries < 1000);
-
-            customPawn.HairDef = pawn.story.hairDef;
-            customPawn.SetColor(PawnLayers.Hair, pawn.story.hairColor);
-            customPawn.HeadGraphicPath = pawn.story.HeadGraphicPath;
-            customPawn.MelaninLevel = pawn.story.melanin;
-
-            for (int i = 0; i < PawnLayers.Count; i++) {
-                if (PawnLayers.IsApparelLayer(i)) {
-                    customPawn.SetSelectedStuff(i, null);
-                    customPawn.SetSelectedApparel(i, null);
-                }
-            }
-            foreach (Apparel current in pawn.apparel.WornApparel) {
-                int layer = PawnLayers.ToPawnLayerIndex(current.def.apparel);
-                if (layer != -1) {
-                    customPawn.SetSelectedStuff(layer, current.Stuff);
-                    customPawn.SetSelectedApparel(layer, current.def);
-                }
-            }
-        }
-
         public void RandomizeName(CustomPawn customPawn) {
-            Pawn pawn = GenerateSameKindOfColonist(customPawn);
+            Pawn pawn = GenerateSameKindOfPawn(customPawn);
             pawn.gender = customPawn.Gender;
             Name name = PawnBioAndNameGenerator.GeneratePawnName(pawn, NameStyle.Full, null);
             NameTriple nameTriple = name as NameTriple;
@@ -133,6 +111,24 @@ namespace EdB.PrepareCarefully {
                 return null;
             }
             return pawns.RandomElement();
+        }
+
+        public Pawn EmptyPawn(PawnKindDef kindDef) {
+            Pawn result = (Pawn)ThingMaker.MakeThing(kindDef.race, null);
+            result.kindDef = kindDef;
+            if (kindDef.RaceProps.hasGenders) {
+                if (this.random.Next(2) == 0) {
+                    result.gender = Gender.Male;
+                }
+                else {
+                    result.gender = Gender.Female;
+                }
+            }
+            else {
+                result.gender = Gender.None;
+            }
+            PawnComponentsUtility.CreateInitialComponents(result);
+            return result;
         }
     }
 }

--- a/Source/Version3/SaveRecordPawnV3.cs
+++ b/Source/Version3/SaveRecordPawnV3.cs
@@ -53,7 +53,7 @@ namespace EdB.PrepareCarefully {
                 this.adulthood = pawn.Adulthood.identifier;
             }
             else {
-                this.adulthood = pawn.LastSelectedAdulthood.identifier;
+                this.adulthood = pawn.LastSelectedAdulthoodBackstory.identifier;
             }
             this.childhood = pawn.Childhood.identifier;
             this.skinColor = pawn.Pawn.story.SkinColor;


### PR DESCRIPTION
Various fixes for faction pawns:
- Centralized dummy faction creation in the faction provider.
- A pawn's faction is now properly maintained when clicking the randomize buttons.
- Better approach to filtering out pawn kinds that cannot be created.
- Implemented a workaround to prevent weapons from being generated with a faction pawn.
- Changed pawn generation context from "non-player" to "player start" in all cases.
Also:
- Moved some functions from `Randomizer` into `ControllerPawns`
- Renamed and reworked some pawn generation `Randomizer` methods
- Added a `CustomPawn.LastSelectedAdulthoodBackstory` property whose getter randomly chooses a backstory if the underlying fields value is null--no longer randomly choosing a value during construction.