### PR TITLE
Preset fix for sibling-only relationships

### DIFF
--- a/EdBPrepareCarefully.csproj
+++ b/EdBPrepareCarefully.csproj
@@ -113,6 +113,7 @@
     <Compile Include="Source\CarefullyPawnRelationDef.cs" />
     <Compile Include="Source\UtilityCopy.cs" />
     <Compile Include="Source\Version3\PresetLoaderVersion3.cs" />
+    <Compile Include="Source\Version3\SaveRecordParentChildGroupV3.cs" />
     <Compile Include="Source\Version3\SaveRecordPawnV3.cs" />
     <Compile Include="Source\Version3\SaveRecordRelationshipV3.cs" />
     <Compile Include="Source\Version3\SaveRecordImplantV3.cs" />

--- a/Resources/CHANGELOG.txt
+++ b/Resources/CHANGELOG.txt
@@ -6,6 +6,8 @@
  - Bug fix: Better filtering of invalid factions and pawn kinds to avoid
    errors when adding a character from a different faction.
  - Bug fix: The randomize options now take into account a character's faction.
+ - Bug fix: Updated preset file format so that sibling-only parent/child
+   groups are no longer lost when saving a preset.
 
  _____________________________________________________________________________
  
@@ -15,6 +17,7 @@
  - Bug fix: Presets that include Alpha 16-saved characters that have had
    relationships added will now save and load properly.
  - Mod compatibility fixes.
+
  _____________________________________________________________________________
  
    Version 0.17.1.2
@@ -24,6 +27,7 @@
    character.
  - Bug fix: Now correctly clearing out health conditions when randomizing a
    character.
+
  _____________________________________________________________________________
  
    Version 0.17.1.1

--- a/Source/Version3/SaveRecordParentChildGroupV3.cs
+++ b/Source/Version3/SaveRecordParentChildGroupV3.cs
@@ -1,0 +1,19 @@
+﻿using RimWorld;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using UnityEngine;
+using Verse;
+using Verse.Sound;
+
+namespace EdB.PrepareCarefully {
+    public class SaveRecordParentChildGroupV3 : IExposable {
+        public List<string> parents;
+        public List<string> children;
+        public void ExposeData() {
+            Scribe_Collections.Look<string>(ref this.parents, "parents", LookMode.Value, null);
+            Scribe_Collections.Look<string>(ref this.children, "children", LookMode.Value, null);
+        }
+    }
+}


### PR DESCRIPTION
- Updated the preset file format to explicitly include parent/child groups (so that sibling-only groups are not lost on save).
- Reworked how the preset loader interacts with the RelationshipManager class.