### PR TITLE
Player faction pawn changes

### DIFF
--- a/Resources/CHANGELOG.txt
+++ b/Resources/CHANGELOG.txt
@@ -3,6 +3,8 @@
    Version 0.17.1.5
  _____________________________________________________________________________
 
+ - Can now choose from both player and non-player factions when creating a
+   new faction pawn.
  - Bug fix: Hidden pawns are not killed if they have already been added into
    the world.
  - Bug fix: Apparel generated for faction pawns is now also set to normal

--- a/Source/ControllerPawns.cs
+++ b/Source/ControllerPawns.cs
@@ -22,7 +22,15 @@ namespace EdB.PrepareCarefully {
         }
 
         public void RandomizeAll() {
-            Pawn pawn = randomizer.GenerateSameKindOfPawn(state.CurrentPawn);
+            // Start by picking a new pawn kind def from the faction.
+            FactionDef factionDef = state.CurrentPawn.Pawn.kindDef.defaultFactionType;
+            if (factionDef == null) {
+                factionDef = Faction.OfPlayer.def;
+            }
+            PawnKindDef kindDef = PrepareCarefully.Instance.Providers.Factions.GetPawnKindsForFactionDefLabel(factionDef)
+                .RandomElementWithFallback(factionDef.basicMemberKind);
+            // Create the pawn.
+            Pawn pawn = randomizer.GenerateKindOfPawn(kindDef);
             state.CurrentPawn.InitializeWithPawn(pawn);
             state.CurrentPawn.GenerateId();
             PawnReplaced(state.CurrentPawn);

--- a/Source/ProviderFactions.cs
+++ b/Source/ProviderFactions.cs
@@ -9,8 +9,6 @@ namespace EdB.PrepareCarefully {
         private List<FactionDef> nonPlayerHumanlikeFactionDefs = new List<FactionDef>();
         private Dictionary<FactionDef, Faction> factionLookup = new Dictionary<FactionDef, Faction>();
         private Dictionary<PawnKindDef, Faction> pawnKindFactionLookup = new Dictionary<PawnKindDef, Faction>();
-        private List<PawnKindDef> nonPlayerPawnKinds = new List<PawnKindDef>();
-        private List<PawnKindDef> playerPawnKinds = new List<PawnKindDef>();
         private Dictionary<FactionDef, List<PawnKindDef>> factionDefPawnKindLookup = new Dictionary<FactionDef, List<PawnKindDef>>();
         public ProviderFactions() {
             foreach (var kindDef in DefDatabase<PawnKindDef>.AllDefs) {
@@ -26,13 +24,6 @@ namespace EdB.PrepareCarefully {
                 // Double-check that it's a humanlike pawn by looking at the value on the faction.
                 if (!faction.def.humanlikeFaction) {
                     continue;
-                }
-                // Sort the pawn kind into player and non-player buckets.
-                if (faction.IsPlayer) {
-                    playerPawnKinds.Add(kindDef);
-                }
-                else {
-                    nonPlayerPawnKinds.Add(kindDef);
                 }
                 // Create a lookup of where you can get the list of pawn kinds given a faction def.
                 // If no valid pawn kinds exist for a faction def, this lookup will have no faction def
@@ -50,14 +41,15 @@ namespace EdB.PrepareCarefully {
                 if (!def.humanlikeFaction) {
                     continue;
                 }
-                if (def.isPlayer || def == Faction.OfPlayer.def) {
+                if (def == Faction.OfPlayer.def) {
                     continue;
                 }
                 List<PawnKindDef> factionKindDefs;
                 if (factionDefPawnKindLookup.TryGetValue(def, out factionKindDefs)) {
                     if (factionKindDefs.Count > 0) {
-                        if (!labels.Contains(def.label)) {
-                            labels.Add(def.label);
+                        string defLabel = def.label.ToLower();
+                        if (!labels.Contains(defLabel)) {
+                            labels.Add(defLabel);
                             nonPlayerHumanlikeFactionDefs.Add(def);
                         }
                     }
@@ -72,16 +64,6 @@ namespace EdB.PrepareCarefully {
                 return nonPlayerHumanlikeFactionDefs;
             }
         }
-        public IEnumerable<PawnKindDef> NonPlayerPawnKinds {
-            get {
-                return nonPlayerPawnKinds;
-            }
-        }
-        public IEnumerable<PawnKindDef> PlayerPawnKinds {
-            get {
-                return playerPawnKinds;
-            }
-        }
         public IEnumerable<PawnKindDef> GetPawnKindsForFactionDef(FactionDef def) {
             List<PawnKindDef> factionDefPawnKinds;
             if (factionDefPawnKindLookup.TryGetValue(def, out factionDefPawnKinds)) {
@@ -92,7 +74,8 @@ namespace EdB.PrepareCarefully {
             }
         }
         public IEnumerable<PawnKindDef> GetPawnKindsForFactionDefLabel(FactionDef def) {
-            var keys = factionDefPawnKindLookup.Keys.Where((FactionDef f) => { return def.LabelCap == f.LabelCap; });
+            string defLabel = def.label.ToLower();
+            var keys = factionDefPawnKindLookup.Keys.Where((FactionDef f) => { return defLabel == f.label.ToLower(); });
             IEnumerable<PawnKindDef> result = null;
             if (keys != null) {
                 foreach (var key in keys) {


### PR DESCRIPTION
- Can now choose from both player and non-player factions when creating a new faction pawn.
- "Randomize All" now chooses between all of the available pawn kinds for the pawn's faction when generating the new random pawn.