### PR TITLE
Fix disabled implant locations

### DIFF
--- a/Resources/CHANGELOG.txt
+++ b/Resources/CHANGELOG.txt
@@ -5,7 +5,9 @@
 
  - Trait tooltips now display conflicting traits.
  - Bug fix: Previous/next buttons for traits now skip over conflicting traits.
-
+ - Bug fix: No longer treating all implants as replaced parts, which was
+   causing implant locations to be disabled in some cases when they should not
+   have been.
  _____________________________________________________________________________
  
    Version 0.17.1.5

--- a/Source/CustomBodyPart.cs
+++ b/Source/CustomBodyPart.cs
@@ -33,10 +33,8 @@ namespace EdB.PrepareCarefully {
             }
         }
 
-        public virtual string Tooltip {
-            get {
-                return "";
-            }
+        public abstract string Tooltip {
+            get;
         }
 
     }

--- a/Source/CustomPawn.cs
+++ b/Source/CustomPawn.cs
@@ -1383,7 +1383,25 @@ namespace EdB.PrepareCarefully {
         public bool IsImplantedPart(BodyPartRecord record) {
             return FindImplant(record) != null;
         }
-
+        public bool AtLeastOneReplacedPart(IEnumerable<BodyPartRecord> records) {
+            foreach (var record in records) {
+                if (IsReplacedPart(record)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        public bool IsReplacedPart(BodyPartRecord record) {
+            Implant implant = FindImplant(record);
+            if (implant == null) {
+                return false;
+            }
+            if (implant.Recipe != null && implant.Recipe.addsHediff != null
+                    && typeof(Hediff_AddedPart).IsAssignableFrom(implant.Recipe.addsHediff.hediffClass)) {
+                return true;
+            }
+            return false;
+        }
         public Implant FindImplant(BodyPartRecord record) {
             if (implants.Count == 0) {
                 return null;

--- a/Source/Implant.cs
+++ b/Source/Implant.cs
@@ -60,18 +60,6 @@ namespace EdB.PrepareCarefully {
             }
         }
 
-        public Hediff_AddedPart AddedBodyPart {
-            get {
-                if (recipe == null) {
-                    return null;
-                }
-                Hediff_AddedPart addedPart = new Hediff_AddedPart();
-                addedPart.Part = BodyPartRecord;
-                addedPart.def = recipe.addsHediff;
-                return addedPart;
-            }
-        }
-
         public string Label {
             get {
                 if (recipe == null) {

--- a/Source/PanelHealth.cs
+++ b/Source/PanelHealth.cs
@@ -454,7 +454,7 @@ namespace EdB.PrepareCarefully {
             OptionsHealth healthOptions = PrepareCarefully.Instance.Providers.Health.GetOptions(pawn);
             foreach (var part in parts) {
                 UniqueBodyPart uniquePart = healthOptions.FindBodyPartsForRecord(part);
-                if (pawn.IsImplantedPart(part) || pawn.AtLeastOneImplantedPart(uniquePart.Ancestors.Select((UniqueBodyPart p) => { return p.Record; }))) {
+                if (pawn.IsReplacedPart(part) || pawn.AtLeastOneReplacedPart(uniquePart.Ancestors.Select((UniqueBodyPart p) => { return p.Record; }))) {
                     disabledBodyParts.Add(part);
                 }
             }

--- a/Source/ScrollViewVertical.cs
+++ b/Source/ScrollViewVertical.cs
@@ -71,12 +71,17 @@ namespace EdB.PrepareCarefully {
         }
 
         public void End(float yPosition) {
-            if (Event.current.type == EventType.Layout) {
-                contentHeight = yPosition;
-            }
+            contentHeight = yPosition;
             Widgets.EndScrollView();
             if (scrollTo != null) {
-                Position = scrollTo.Value;
+                Vector2 newPosition = scrollTo.Value;
+                if (newPosition.y < 0) {
+                    newPosition.y = 0;
+                }
+                else if (newPosition.y > ContentHeight - ViewHeight - 1) {
+                    newPosition.y = ContentHeight - ViewHeight - 1;
+                }
+                Position = newPosition;
                 scrollTo = null;
             }
         }
@@ -90,12 +95,6 @@ namespace EdB.PrepareCarefully {
         }
 
         public void ScrollTo(float y) {
-            if (y < 0) {
-                y = 0;
-            }
-            else if (y > ContentHeight - ViewHeight) {
-                y = ContentHeight - ViewHeight;
-            }
             scrollTo = new Vector2(0, y);
         }
 


### PR DESCRIPTION
- No longer treating all implants as replaced parts, which was causing implant locations to be disabled in some cases when they should not have been.
- Also tweaked the way that scroll views evaluate the `scrollTo` location.