### PR TITLE
Removed faction value from pawns

### DIFF
--- a/Source/ControllerPawns.cs
+++ b/Source/ControllerPawns.cs
@@ -246,7 +246,6 @@ namespace EdB.PrepareCarefully {
             }
 
             CustomPawn customPawn = new CustomPawn(pawn);
-            customPawn.Pawn.SetFactionDirect(Faction.OfPlayer);
             PrepareCarefully.Instance.AddPawn(customPawn);
             state.CurrentPawn = customPawn;
             PawnAdded(customPawn);

--- a/Source/CustomPawn.cs
+++ b/Source/CustomPawn.cs
@@ -109,15 +109,6 @@ namespace EdB.PrepareCarefully {
             }
         }
 
-        public Faction Faction {
-            get {
-                return pawn.Faction;
-            }
-            set {
-                pawn.SetFactionDirect(value);
-            }
-        }
-
         public int MinAge {
             get {
                 return Constraints.AgeBiologicalMin;
@@ -221,6 +212,9 @@ namespace EdB.PrepareCarefully {
             
             // Set the alien race, if any.
             alienRace = PrepareCarefully.Instance.Providers.AlienRaces.GetAlienRace(pawn.def);
+
+            // Clear out the faction.
+            pawn.SetFactionDirect(null);
 
             // Clear all of the pawn caches.
             ClearPawnCaches();

--- a/Source/PanelName.cs
+++ b/Source/PanelName.cs
@@ -1,5 +1,7 @@
 using RimWorld;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using Verse;
 using Verse.Sound;

--- a/Source/PrepareCarefully.cs
+++ b/Source/PrepareCarefully.cs
@@ -361,6 +361,7 @@ namespace EdB.PrepareCarefully {
         public void CreateColonists() {
             colonists.Clear();
             foreach (CustomPawn customPawn in pawns) {
+                customPawn.Pawn.SetFactionDirect(Faction.OfPlayer);
                 if (customPawn.Pawn.workSettings == null) {
                     customPawn.Pawn.workSettings = new Pawn_WorkSettings(customPawn.Pawn);
                 }


### PR DESCRIPTION
- Removed the faction from all pawns while they are being prepared. This avoids a bug in the info health panel related to self-doctoring.
- The faction is now set when preparing pawns for spawn.