### PR TITLE
Pawn relationship compatibility fixes

### DIFF
--- a/Resources/Defs/CarefullyPawnRelationDefs/CarefullyPawnRelations_FamilyByChoice.xml
+++ b/Resources/Defs/CarefullyPawnRelationDefs/CarefullyPawnRelations_FamilyByChoice.xml
@@ -4,6 +4,7 @@
   <EdB.PrepareCarefully.CarefullyPawnRelationDef>
     <defName>Spouse</defName>
     <inverse>Spouse</inverse>
+    <needsCompatibility>true</needsCompatibility>
 	<conflicts>
 		<li>Lover</li>
 		<li>ExSpouse</li>
@@ -14,11 +15,13 @@
   <EdB.PrepareCarefully.CarefullyPawnRelationDef>
     <defName>Fiance</defName>
     <inverse>Fiance</inverse>
-  </EdB.PrepareCarefully.CarefullyPawnRelationDef>
+    <needsCompatibility>true</needsCompatibility>
+</EdB.PrepareCarefully.CarefullyPawnRelationDef>
   
   <EdB.PrepareCarefully.CarefullyPawnRelationDef>
     <defName>Lover</defName>
     <inverse>Lover</inverse>
+    <needsCompatibility>true</needsCompatibility>
 	<conflicts>
 		<li>Spouse</li>
 		<li>ExSpouse</li>

--- a/Source/CarefullyPawnRelationDef.cs
+++ b/Source/CarefullyPawnRelationDef.cs
@@ -13,6 +13,8 @@ namespace EdB.PrepareCarefully {
 
         public Type workerClass = null;
 
+        public bool needsCompatibility = false;
+
         [Unsaved]
         private PawnRelationWorker worker;
 


### PR DESCRIPTION
- Added field to CarefullyPawnRelationDef to indicate whether or not a relationship should try to find more compatible pawns.
- Updated relationship builder to reassign pawn ThingIds to try to end up with more compatible pawns.