### PR TITLE
Revert null faction workaround

### DIFF
--- a/Source/CustomPawn.cs
+++ b/Source/CustomPawn.cs
@@ -213,9 +213,6 @@ namespace EdB.PrepareCarefully {
             // Set the alien race, if any.
             alienRace = PrepareCarefully.Instance.Providers.AlienRaces.GetAlienRace(pawn.def);
 
-            // Clear out the faction.
-            pawn.SetFactionDirect(null);
-
             // Clear all of the pawn caches.
             ClearPawnCaches();
         }


### PR DESCRIPTION
Reverted the change that set the pawn's faction to null while Prepare Carefully.  Doing so avoided an exception in the health info tab in some cases, but it also breaks compatibility with the Facial Stuff mod.  Will live with the health tab bug until we can find another approach.