### PR TITLE
Fixed Alien Races hair color swatches not showing up.

### DIFF
--- a/EdBPrepareCarefully.csproj
+++ b/EdBPrepareCarefully.csproj
@@ -38,9 +38,11 @@
     <Reference Include="System.Xml.Linq" />
     <Reference Include="Assembly-CSharp">
       <HintPath>Libraries\Assembly-CSharp.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine">
       <HintPath>Libraries\UnityEngine.dll</HintPath>
+      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Source/ProviderAlienRaces.cs
+++ b/Source/ProviderAlienRaces.cs
@@ -217,7 +217,7 @@ namespace EdB.PrepareCarefully {
             object hairColorGeneratorValue = GetFieldValue(raceDef, alienPartGeneratorObject, "alienhaircolorgen", true);
             ColorGenerator hairColorGenerator = hairColorGeneratorValue as ColorGenerator;
             if (hairColorGenerator != null) {
-                result.HairColors = primaryGenerator.GetColorList();
+                result.HairColors = hairColorGenerator.GetColorList();
             }
             else {
                 result.HairColors = null;

--- a/Source/ProviderHair.cs
+++ b/Source/ProviderHair.cs
@@ -85,6 +85,11 @@ namespace EdB.PrepareCarefully {
             })) {
                 result.AddHair(hairDef);
             }
+            
+            if (alienRace.HairColors != null) {
+                result.Colors = alienRace.HairColors.ToList();
+            }
+            
             result.Sort();
             return result;
         }


### PR DESCRIPTION
Basically this was in issue in two parts.
One:
The results to grab the hair colors would return the skin colors instead of the hair swatches.
Two:
There was no check that applied the hair swatches unless there was no custom set hair.