### PR TITLE
Version 1.1.3

### DIFF
--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -14,4 +14,4 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyVersion("1.1.1")]
 
 // Increment for each new release
-[assembly: AssemblyFileVersion("1.1.2")]
+[assembly: AssemblyFileVersion("1.1.3")]

--- a/Resources/About/About.xml
+++ b/Resources/About/About.xml
@@ -12,6 +12,6 @@
 
 If you get a set of starting colonists that you like, save them as a preset so that you can start your game the same way next time.
 
-[Version 1.1.2]
+[Version 1.1.3]
 </description>
 </ModMetaData>

--- a/Resources/About/Manifest.xml
+++ b/Resources/About/Manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Manifest>
     <identifier>EdBPrepareCarefully</identifier>
-    <version>1.1.2</version>
+    <version>1.1.3</version>
     <loadAfter>
         <li>Core</li>
         <li>HugsLib</li>

--- a/Source/AlienRace.cs
+++ b/Source/AlienRace.cs
@@ -22,6 +22,9 @@ namespace EdB.PrepareCarefully {
         public bool HasSecondaryColor {
             get; set;
         }
+        public bool ChangeableColor {
+            get; set;
+        }
         public List<Color> PrimaryColors {
             get; set;
         }

--- a/Source/PanelAppearance.cs
+++ b/Source/PanelAppearance.cs
@@ -342,7 +342,7 @@ namespace EdB.PrepareCarefully {
                 if (alienRace == null || alienRace.UseMelaninLevels) {
                     DrawHumanlikeColorSelector(customPawn, cursorY);
                 }
-                else {
+                else if (alienRace.ChangeableColor) {
                     DrawAlienPawnColorSelector(customPawn, cursorY, alienRace.PrimaryColors, true);
                 }
             }
@@ -545,31 +545,33 @@ namespace EdB.PrepareCarefully {
             Color currentColor = customPawn.Pawn.story.SkinColor;
             Color clickedColor = currentColor;
             Rect rect = new Rect(SwatchPosition.x, cursorY, SwatchSize.x, SwatchSize.y);
-            foreach (Color color in colors) {
-                bool selected = (color == currentColor);
-                if (selected) {
-                    Rect selectionRect = new Rect(rect.x - 2, rect.y - 2, SwatchSize.x + 4, SwatchSize.y + 4);
-                    GUI.color = ColorSwatchSelection;
-                    GUI.DrawTexture(selectionRect, BaseContent.WhiteTex);
-                }
-
-                Rect borderRect = new Rect(rect.x - 1, rect.y - 1, SwatchSize.x + 2, SwatchSize.y + 2);
-                GUI.color = ColorSwatchBorder;
-                GUI.DrawTexture(borderRect, BaseContent.WhiteTex);
-
-                GUI.color = color;
-                GUI.DrawTexture(rect, BaseContent.WhiteTex);
-
-                if (!selected) {
-                    if (Widgets.ButtonInvisible(rect, false)) {
-                        clickedColor = color;
+            if (colors != null) {
+                foreach (Color color in colors) {
+                    bool selected = (color == currentColor);
+                    if (selected) {
+                        Rect selectionRect = new Rect(rect.x - 2, rect.y - 2, SwatchSize.x + 4, SwatchSize.y + 4);
+                        GUI.color = ColorSwatchSelection;
+                        GUI.DrawTexture(selectionRect, BaseContent.WhiteTex);
                     }
-                }
 
-                rect.x += SwatchSpacing.x;
-                if (rect.x >= SwatchLimit - SwatchSize.x) {
-                    rect.y += SwatchSpacing.y;
-                    rect.x = SwatchPosition.x;
+                    Rect borderRect = new Rect(rect.x - 1, rect.y - 1, SwatchSize.x + 2, SwatchSize.y + 2);
+                    GUI.color = ColorSwatchBorder;
+                    GUI.DrawTexture(borderRect, BaseContent.WhiteTex);
+
+                    GUI.color = color;
+                    GUI.DrawTexture(rect, BaseContent.WhiteTex);
+
+                    if (!selected) {
+                        if (Widgets.ButtonInvisible(rect, false)) {
+                            clickedColor = color;
+                        }
+                    }
+
+                    rect.x += SwatchSpacing.x;
+                    if (rect.x >= SwatchLimit - SwatchSize.x) {
+                        rect.y += SwatchSpacing.y;
+                        rect.x = SwatchPosition.x;
+                    }
                 }
             }
 

--- a/Source/PanelAppearance.cs
+++ b/Source/PanelAppearance.cs
@@ -93,7 +93,7 @@ namespace EdB.PrepareCarefully {
                                     return 1;
                                 }
                                 else {
-                                    return a.LabelCap.Resolve().CompareTo(b.LabelCap);
+                                    return a.LabelCap.Resolve().CompareTo(b.LabelCap.Resolve());
                                 }
                             }
                             else {

--- a/Source/PanelEquipmentAvailable.cs
+++ b/Source/PanelEquipmentAvailable.cs
@@ -1,4 +1,4 @@
-﻿using RimWorld;
+using RimWorld;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -288,7 +288,7 @@ namespace EdB.PrepareCarefully {
                     stuffFilterOptions.Add(new FloatMenuOption("EdB.PC.Panel.AvailableEquipment.Materials.None".Translate(), () => {
                         UpdateStuffFilter(false, null);
                     }, MenuOptionPriority.Default, null, null, 0, null, null));
-                    foreach (var item in stuffFilterSet.OrderBy((ThingDef def) => { return def.LabelCap; })) {
+                    foreach (var item in stuffFilterSet.OrderBy((ThingDef def) => { return def.LabelCap.Resolve(); })) {
                         stuffFilterOptions.Add(new FloatMenuOption(item.LabelCap, () => {
                             UpdateStuffFilter(true, item);
                         }, MenuOptionPriority.Default, null, null, 0, null, null));

--- a/Source/ProviderAlienRaces.cs
+++ b/Source/ProviderAlienRaces.cs
@@ -74,212 +74,229 @@ namespace EdB.PrepareCarefully {
             return (alienRaceField != null);
         }
         protected AlienRace InitializeAlienRace(ThingDef raceDef) {
-            object alienRaceObject = GetFieldValue(raceDef, raceDef, "alienRace");
-            if (alienRaceObject == null) {
-                return null;
-            }
-            object generalSettingsObject = GetFieldValue(raceDef, alienRaceObject, "generalSettings");
-            if (generalSettingsObject == null) {
-                return null;
-            }
-            object alienPartGeneratorObject = GetFieldValue(raceDef, generalSettingsObject, "alienPartGenerator");
-            if (alienPartGeneratorObject == null) {
-                return null;
-            }
-            System.Collections.ICollection graphicPathsCollection = GetFieldValueAsCollection(raceDef, alienRaceObject, "graphicPaths");
-            if (graphicPathsCollection == null) {
-                return null;
-            }
-
-            /*
-            Log.Message("GraphicsPaths for " + raceDef.defName + ":");
-            if (graphicPathsCollection.Count > 0) {
-                foreach (object o in graphicPathsCollection) {
-                    Log.Message("  GraphicsPath");
-                    Log.Message("    .body = " + GetFieldValueAsString(raceDef, o, "body"));
-                    Log.Message("    .head = " + GetFieldValueAsString(raceDef, o, "head"));
-                    System.Collections.ICollection lifeStagesCollections = GetFieldValueAsCollection(raceDef, o, "lifeStageDefs");
+            try {
+                object alienRaceObject = GetFieldValue(raceDef, raceDef, "alienRace");
+                if (alienRaceObject == null) {
+                    return null;
                 }
-            }
-            */
+                object generalSettingsObject = GetFieldValue(raceDef, alienRaceObject, "generalSettings");
+                if (generalSettingsObject == null) {
+                    return null;
+                }
+                object alienPartGeneratorObject = GetFieldValue(raceDef, generalSettingsObject, "alienPartGenerator");
+                if (alienPartGeneratorObject == null) {
+                    return null;
+                }
+                System.Collections.ICollection graphicPathsCollection = GetFieldValueAsCollection(raceDef, alienRaceObject, "graphicPaths");
+                if (graphicPathsCollection == null) {
+                    return null;
+                }
 
-            // We have enough to start putting together the result object, so we instantiate it now.
-            AlienRace result = new AlienRace();
-            result.ThingDef = raceDef;
-
-            // Get the list of body types.
-            System.Collections.ICollection alienBodyTypesCollection = GetFieldValueAsCollection(raceDef, alienPartGeneratorObject, "alienbodytypes");
-            if (alienBodyTypesCollection == null) {
-                return null;
-            }
-            List<BodyTypeDef> bodyTypes = new List<BodyTypeDef>();
-            //Log.Message("Body Types for " + raceDef.defName + ":");
-            if (alienBodyTypesCollection.Count > 0) {
-                foreach (object o in alienBodyTypesCollection) {
-                    if (o.GetType() == typeof(BodyTypeDef)) {
-                        BodyTypeDef def = o as BodyTypeDef;
-                        //Log.Message("  " + def.defName + ", " + def.LabelCap);
-                        bodyTypes.Add((BodyTypeDef)o);
+                /*
+                Log.Message("GraphicsPaths for " + raceDef.defName + ":");
+                if (graphicPathsCollection.Count > 0) {
+                    foreach (object o in graphicPathsCollection) {
+                        Log.Message("  GraphicsPath");
+                        Log.Message("    .body = " + GetFieldValueAsString(raceDef, o, "body"));
+                        Log.Message("    .head = " + GetFieldValueAsString(raceDef, o, "head"));
+                        System.Collections.ICollection lifeStagesCollections = GetFieldValueAsCollection(raceDef, o, "lifeStageDefs");
                     }
                 }
-            }
-            result.BodyTypes = bodyTypes;
+                */
 
-            // Determine if the alien races uses gender-specific heads.
-            bool? useGenderedHeads = GetFieldValueAsBool(raceDef, alienPartGeneratorObject, "useGenderedHeads");
-            if (useGenderedHeads == null) {
-                return null;
-            }
-            result.GenderSpecificHeads = useGenderedHeads.Value;
+                // We have enough to start putting together the result object, so we instantiate it now.
+                AlienRace result = new AlienRace();
+                result.ThingDef = raceDef;
 
-            // Get the list of crown types.
-            System.Collections.ICollection alienCrownTypesCollection = GetFieldValueAsCollection(raceDef, alienPartGeneratorObject, "aliencrowntypes");
-            if (alienCrownTypesCollection == null) {
-                return null;
-            }
-            List<string> crownTypes = new List<string>();
-            //Log.Message("Crown Types for " + raceDef.defName + ":");
-            if (alienCrownTypesCollection.Count > 0) {
-                foreach (object o in alienCrownTypesCollection) {
-                    string crownTypeString = o as string;
-                    if (crownTypeString != null) {
-                        crownTypes.Add(crownTypeString);
-                        //Log.Message("  " + crownTypeString);
+                //Logger.Debug("InitializeAlienRace: " + raceDef.defName);
+
+                // Get the list of body types.
+                System.Collections.ICollection alienBodyTypesCollection = GetFieldValueAsCollection(raceDef, alienPartGeneratorObject, "alienbodytypes");
+                if (alienBodyTypesCollection == null) {
+                    return null;
+                }
+                List<BodyTypeDef> bodyTypes = new List<BodyTypeDef>();
+                //Logger.Debug("Body Types for " + raceDef.defName + ":");
+                if (alienBodyTypesCollection.Count > 0) {
+                    foreach (object o in alienBodyTypesCollection) {
+                        if (o.GetType() == typeof(BodyTypeDef)) {
+                            BodyTypeDef def = o as BodyTypeDef;
+                            //Log.Debug("  - " + def.defName + ", " + def.LabelCap);
+                            bodyTypes.Add((BodyTypeDef)o);
+                        }
                     }
                 }
-            }
-            result.CrownTypes = crownTypes;
+                else {
+                    //Log.Debug("  none");
+                }
+                result.BodyTypes = bodyTypes;
 
-            // Go through the graphics paths and find the heads path.
-            // TODO: What is this?  
-            string graphicsPathForHeads = null;
-            string graphicsPathForBodyTypes = null;
-            foreach (var graphicsPath in graphicPathsCollection) {
-                System.Collections.ICollection lifeStageCollection = GetFieldValueAsCollection(raceDef, graphicsPath, "lifeStageDefs");
-                if (lifeStageCollection == null || lifeStageCollection.Count == 0) {
-                    string headsPath = GetFieldValueAsString(raceDef, graphicsPath, "head");
-                    string bodyTypesPath = GetFieldValueAsString(raceDef, graphicsPath, "body");
-                    if (headsPath != null) {
-                        graphicsPathForHeads = headsPath;
-                    }
-                    if (bodyTypesPath != null) {
-                        graphicsPathForBodyTypes = bodyTypesPath;
+                // Determine if the alien races uses gender-specific heads.
+                bool? useGenderedHeads = GetFieldValueAsBool(raceDef, alienPartGeneratorObject, "useGenderedHeads");
+                if (useGenderedHeads == null) {
+                    return null;
+                }
+                result.GenderSpecificHeads = useGenderedHeads.Value;
+
+                // Get the list of crown types.
+                System.Collections.ICollection alienCrownTypesCollection = GetFieldValueAsCollection(raceDef, alienPartGeneratorObject, "aliencrowntypes");
+                if (alienCrownTypesCollection == null) {
+                    return null;
+                }
+                List<string> crownTypes = new List<string>();
+                //Log.Message("Crown Types for " + raceDef.defName + ":");
+                if (alienCrownTypesCollection.Count > 0) {
+                    foreach (object o in alienCrownTypesCollection) {
+                        string crownTypeString = o as string;
+                        if (crownTypeString != null) {
+                            crownTypes.Add(crownTypeString);
+                            //Log.Message("  " + crownTypeString);
+                        }
                     }
                 }
-            }
-            result.GraphicsPathForHeads = graphicsPathForHeads;
-            result.GraphicsPathForBodyTypes = graphicsPathForBodyTypes;
+                result.CrownTypes = crownTypes;
 
-            // Figure out colors.
-            object primaryColorGeneratorValue = GetFieldValue(raceDef, alienPartGeneratorObject, "alienskincolorgen", true);
-            result.UseMelaninLevels = true;
-            ColorGenerator primaryGenerator = primaryColorGeneratorValue as ColorGenerator;
-            if (primaryGenerator.GetType().Name != "ColorGenerator_SkinColorMelanin") {
+                // Go through the graphics paths and find the heads path.
+                // TODO: What is this?  
+                string graphicsPathForHeads = null;
+                string graphicsPathForBodyTypes = null;
+                foreach (var graphicsPath in graphicPathsCollection) {
+                    System.Collections.ICollection lifeStageCollection = GetFieldValueAsCollection(raceDef, graphicsPath, "lifeStageDefs");
+                    if (lifeStageCollection == null || lifeStageCollection.Count == 0) {
+                        string headsPath = GetFieldValueAsString(raceDef, graphicsPath, "head");
+                        string bodyTypesPath = GetFieldValueAsString(raceDef, graphicsPath, "body");
+                        if (headsPath != null) {
+                            graphicsPathForHeads = headsPath;
+                        }
+                        if (bodyTypesPath != null) {
+                            graphicsPathForBodyTypes = bodyTypesPath;
+                        }
+                    }
+                }
+                result.GraphicsPathForHeads = graphicsPathForHeads;
+                result.GraphicsPathForBodyTypes = graphicsPathForBodyTypes;
+
+                // Figure out colors.
+                object primaryColorGeneratorValue = GetFieldValue(raceDef, alienPartGeneratorObject, "alienskincolorgen", true);
+                result.UseMelaninLevels = true;
+                result.ChangeableColor = true;
+                ColorGenerator primaryGenerator = primaryColorGeneratorValue as ColorGenerator;
                 if (primaryGenerator != null) {
-                    result.UseMelaninLevels = false;
-                    result.PrimaryColors = primaryGenerator.GetColorList();
-                }
-                else {
-                    result.PrimaryColors = new List<Color>();
-                }
-                object secondaryColorGeneratorValue = GetFieldValue(raceDef, alienPartGeneratorObject, "alienskinsecondcolorgen", true);
-                result.HasSecondaryColor = false;
-                ColorGenerator secondaryGenerator = secondaryColorGeneratorValue as ColorGenerator;
-                if (secondaryGenerator != null) {
-                    result.HasSecondaryColor = true;
-                    result.SecondaryColors = secondaryGenerator.GetColorList();
-                }
-                else {
-                    result.SecondaryColors = new List<Color>();
-                }
-            }
-
-            // Hair properties.
-            object hairSettingsValue = GetFieldValue(raceDef, alienRaceObject, "hairSettings", true);
-            result.HasHair = true;
-            if (hairSettingsValue != null) {
-                bool? hasHair = GetFieldValueAsBool(raceDef, hairSettingsValue, "hasHair");
-                if (hasHair != null) {
-                    result.HasHair = hasHair.Value;
-                }
-                var hairTagCollection = GetFieldValueAsCollection(raceDef, hairSettingsValue, "hairTags");
-                if (hairTagCollection != null) {
-                    var hairTags = new HashSet<string>();
-                    foreach (var o in hairTagCollection) {
-                        string tag = o as string;
-                        if (tag != null) {
-                            hairTags.Add(tag);
+                    if (primaryGenerator.GetType().Name != "ColorGenerator_SkinColorMelanin") {
+                        if (primaryGenerator != null) {
+                            result.UseMelaninLevels = false;
+                            result.PrimaryColors = primaryGenerator.GetColorList();
+                        }
+                        else {
+                            result.PrimaryColors = new List<Color>();
+                        }
+                        object secondaryColorGeneratorValue = GetFieldValue(raceDef, alienPartGeneratorObject, "alienskinsecondcolorgen", true);
+                        result.HasSecondaryColor = false;
+                        ColorGenerator secondaryGenerator = secondaryColorGeneratorValue as ColorGenerator;
+                        if (secondaryGenerator != null) {
+                            result.HasSecondaryColor = true;
+                            result.SecondaryColors = secondaryGenerator.GetColorList();
+                        }
+                        else {
+                            result.SecondaryColors = new List<Color>();
                         }
                     }
-                    if (hairTags.Count > 0) {
-                        result.HairTags = hairTags;
-                    }
                 }
-            }
-            object hairColorGeneratorValue = GetFieldValue(raceDef, alienPartGeneratorObject, "alienhaircolorgen", true);
-            ColorGenerator hairColorGenerator = hairColorGeneratorValue as ColorGenerator;
-            if (hairColorGenerator != null) {
-                result.HairColors = hairColorGenerator.GetColorList();
-            }
-            else {
-                result.HairColors = null;
-            }
+                else {
+                    result.UseMelaninLevels = true;
+                }
 
-            // Apparel properties.
-            object restrictionSettingsValue = GetFieldValue(raceDef, alienRaceObject, "raceRestriction", true);
-            result.RestrictedApparelOnly = false;
-            if (restrictionSettingsValue != null) {
-                bool? restrictedApparelOnly = GetFieldValueAsBool(raceDef, restrictionSettingsValue, "onlyUseRaceRestrictedApparel");
-                if (restrictedApparelOnly != null) {
-                    result.RestrictedApparelOnly = restrictedApparelOnly.Value;
-                }
-                var restrictedApparelCollection = GetFieldValueAsCollection(raceDef, restrictionSettingsValue, "apparelList");
-                if (restrictedApparelCollection != null) {
-                    var apparel = new HashSet<string>();
-                    foreach (var o in restrictedApparelCollection) {
-                        string defName = o as string;
-                        if (defName != null) {
-                            apparel.Add(defName);
+                // Hair properties.
+                object hairSettingsValue = GetFieldValue(raceDef, alienRaceObject, "hairSettings", true);
+                result.HasHair = true;
+                if (hairSettingsValue != null) {
+                    bool? hasHair = GetFieldValueAsBool(raceDef, hairSettingsValue, "hasHair");
+                    if (hasHair != null) {
+                        result.HasHair = hasHair.Value;
+                    }
+                    var hairTagCollection = GetFieldValueAsCollection(raceDef, hairSettingsValue, "hairTags");
+                    if (hairTagCollection != null) {
+                        var hairTags = new HashSet<string>();
+                        foreach (var o in hairTagCollection) {
+                            string tag = o as string;
+                            if (tag != null) {
+                                hairTags.Add(tag);
+                            }
+                        }
+                        if (hairTags.Count > 0) {
+                            result.HairTags = hairTags;
                         }
                     }
-                    if (apparel.Count > 0) {
-                        result.RestrictedApparel = apparel;
+                }
+
+                object hairColorGeneratorValue = GetFieldValue(raceDef, alienPartGeneratorObject, "alienhaircolorgen", true);
+                ColorGenerator hairColorGenerator = hairColorGeneratorValue as ColorGenerator;
+                if (hairColorGenerator != null) {
+                    result.HairColors = hairColorGenerator.GetColorList();
+                }
+                else {
+                    result.HairColors = null;
+                }
+
+                // Apparel properties.
+                object restrictionSettingsValue = GetFieldValue(raceDef, alienRaceObject, "raceRestriction", true);
+                result.RestrictedApparelOnly = false;
+                if (restrictionSettingsValue != null) {
+                    bool? restrictedApparelOnly = GetFieldValueAsBool(raceDef, restrictionSettingsValue, "onlyUseRaceRestrictedApparel");
+                    if (restrictedApparelOnly != null) {
+                        result.RestrictedApparelOnly = restrictedApparelOnly.Value;
+                    }
+                    var restrictedApparelCollection = GetFieldValueAsCollection(raceDef, restrictionSettingsValue, "apparelList");
+                    if (restrictedApparelCollection != null) {
+                        var apparel = new HashSet<string>();
+                        foreach (var o in restrictedApparelCollection) {
+                            string defName = o as string;
+                            if (defName != null) {
+                                apparel.Add(defName);
+                            }
+                        }
+                        if (apparel.Count > 0) {
+                            result.RestrictedApparel = apparel;
+                        }
                     }
                 }
-            }
 
-            var bodyAddonsCollection = GetFieldValueAsCollection(raceDef, alienPartGeneratorObject, "bodyAddons");
-            if (bodyAddonsCollection != null ) {
-                var addons = new List<AlienRaceBodyAddon>();
-                int index = -1;
-                foreach (var o in bodyAddonsCollection) {
-                    index++;
-                    AlienRaceBodyAddon addon = new AlienRaceBodyAddon();
-                    string path = GetFieldValueAsString(raceDef, o, "path");
-                    if (path == null) {
-                        Log.Warning("Failed to get path for body add-on for alien race: " + raceDef.defName);
-                        continue;
+                var bodyAddonsCollection = GetFieldValueAsCollection(raceDef, alienPartGeneratorObject, "bodyAddons");
+                if (bodyAddonsCollection != null) {
+                    var addons = new List<AlienRaceBodyAddon>();
+                    int index = -1;
+                    foreach (var o in bodyAddonsCollection) {
+                        index++;
+                        AlienRaceBodyAddon addon = new AlienRaceBodyAddon();
+                        string path = GetFieldValueAsString(raceDef, o, "path");
+                        if (path == null) {
+                            Log.Warning("Failed to get path for body add-on for alien race: " + raceDef.defName);
+                            continue;
+                        }
+                        addon.Path = path;
+                        int? variantCount = GetFieldValueAsInt(raceDef, o, "variantCount");
+                        if (variantCount == null) {
+                            Log.Warning("Failed to get variant count for body add-on for alien race: " + raceDef.defName);
+                            continue;
+                        }
+                        addon.OptionCount = variantCount.Value;
+                        string name = ParseAddonName(path);
+                        if (name == null) {
+                            Log.Warning("Failed to parse a name from its path for body add-on for alien race: " + raceDef.defName);
+                            continue;
+                        }
+                        addon.Name = name;
+                        addon.VariantIndex = index;
+                        addons.Add(addon);
                     }
-                    addon.Path = path;
-                    int? variantCount = GetFieldValueAsInt(raceDef, o, "variantCount");
-                    if (variantCount == null) {
-                        Log.Warning("Failed to get variant count for body add-on for alien race: " + raceDef.defName);
-                        continue;
-                    }
-                    addon.OptionCount = variantCount.Value;
-                    string name = ParseAddonName(path);
-                    if (name == null) {
-                        Log.Warning("Failed to parse a name from its path for body add-on for alien race: " + raceDef.defName);
-                        continue;
-                    }
-                    addon.Name = name;
-                    addon.VariantIndex = index;
-                    addons.Add(addon);
+                    result.addons = addons;
                 }
-                result.addons = addons;
-            }
 
-            return result;
+                return result;
+            }
+            catch (Exception e) {
+                throw new InitializationException("Failed to initialize an alien race: " + raceDef.defName, e);
+            }
         }
         protected string ParseAddonName(string path) {
             string trimmedPath = path.TrimEnd('/').TrimStart('/');

--- a/Source/Randomizer.cs
+++ b/Source/Randomizer.cs
@@ -100,18 +100,7 @@ namespace EdB.PrepareCarefully {
         }
 
         public static Backstory RandomAdulthood(CustomPawn customPawn) {
-            PawnKindDef kindDef = customPawn.Pawn.kindDef;
-            FactionDef factionDef = kindDef.defaultFactionType;
-            if (factionDef == null) {
-                factionDef = Faction.OfPlayer.def;
-            }
-
-            List<BackstoryCategoryFilter> backstoryCategoryFiltersFor = Reflection.PawnBioAndNameGenerator
-                .GetBackstoryCategoryFiltersFor(customPawn.Pawn, factionDef);
-            if (!Reflection.PawnBioAndNameGenerator.TryGetRandomUnusedSolidBioFor(backstoryCategoryFiltersFor, kindDef, customPawn.Gender, null, out PawnBio pawnBio)) {
-                return customPawn.Adulthood;
-            }
-            return pawnBio.adulthood;
+            return PrepareCarefully.Instance.Providers.Backstories.GetAdulthoodBackstoriesForPawn(customPawn).RandomElement();
         }
 
         public void RandomizeName(CustomPawn customPawn) {

--- a/Source/Version4/SaveRecordPawnV4.cs
+++ b/Source/Version4/SaveRecordPawnV4.cs
@@ -62,7 +62,7 @@ namespace EdB.PrepareCarefully {
                 this.adulthood = pawn.Adulthood.identifier;
             }
             else {
-                this.adulthood = pawn.LastSelectedAdulthoodBackstory.identifier;
+                this.adulthood = pawn.LastSelectedAdulthoodBackstory?.identifier;
             }
             this.childhood = pawn.Childhood.identifier;
             this.skinColor = pawn.Pawn.story.SkinColor;


### PR DESCRIPTION
- Fixed problems with sorting `TaggedString`s.  We need to call `Resolve()` on them before passing them as an argument to a `Compare()` method
- Fixed a null-pointer caused by Alien Race definitions that have a null `ColorGenerator`  
- Changed `Randomizer.RandomAdulthood()` to choose a random backstory from a list provided by `ProviderBackstories`.
  - The previous implementation was returning `null` instead of a valid backstory
  - This was causing a null-pointer exception when saving a preset because `CustomPawn.LastSelectedAdultBackstory` would unexpectedly return `null`.  We added a null-pointer check in the preset saving code