### PR TITLE
Version 1.1.4

### DIFF
--- a/EdBPrepareCarefully.csproj
+++ b/EdBPrepareCarefully.csproj
@@ -111,6 +111,7 @@
     <Compile Include="Source\PanelRelationshipsParentChild.cs" />
     <Compile Include="Source\HarmonyPatches.cs" />
     <Compile Include="Source\PanelWorldPawnList.cs" />
+    <Compile Include="Source\PawnBioGenerator.cs" />
     <Compile Include="Source\PawnGenerationRequestWrapper.cs" />
     <Compile Include="Source\PawnLayer.cs" />
     <Compile Include="Source\PawnLayerAlienAddon.cs" />

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("EdB Prepare Carefully Mod")]
-[assembly: AssemblyCopyright("Copyright © 2014-2019")]
+[assembly: AssemblyCopyright("Copyright © 2014-2020")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -14,4 +14,4 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyVersion("1.1.1")]
 
 // Increment for each new release
-[assembly: AssemblyFileVersion("1.1.3")]
+[assembly: AssemblyFileVersion("1.1.4")]

--- a/Resources/About/About.xml
+++ b/Resources/About/About.xml
@@ -12,6 +12,6 @@
 
 If you get a set of starting colonists that you like, save them as a preset so that you can start your game the same way next time.
 
-[Version 1.1.3]
+[Version 1.1.4]
 </description>
 </ModMetaData>

--- a/Resources/About/Manifest.xml
+++ b/Resources/About/Manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Manifest>
     <identifier>EdBPrepareCarefully</identifier>
-    <version>1.1.3</version>
+    <version>1.1.4</version>
     <loadAfter>
         <li>Core</li>
         <li>HugsLib</li>

--- a/Resources/CHANGELOG.txt
+++ b/Resources/CHANGELOG.txt
@@ -1,5 +1,15 @@
  _____________________________________________________________________________
  
+   Version 1.1.4
+ _____________________________________________________________________________
+
+  - Fixed an issue when adding faction pawns from the Shattered Empire.
+  - Compatibility fix with Vanilla Hair Expanded.
+  - Fixed an issue with the randomize backstories button when the Alien Races
+    mod is enabled.
+
+ _____________________________________________________________________________
+ 
    Version 1.1.3
  _____________________________________________________________________________
 

--- a/Source/ControllerPawns.cs
+++ b/Source/ControllerPawns.cs
@@ -332,6 +332,12 @@ namespace EdB.PrepareCarefully {
                 a.HitPoints = a.MaxHitPoints;
             }
 
+            // TODO: Revisit this if we add a UI to edit titles.
+            // Clear out all titles.
+            if (pawn.royalty != null) {
+                pawn.royalty = new Pawn_RoyaltyTracker(pawn);
+            }
+
             CustomPawn customPawn = new CustomPawn(pawn);
             customPawn.OriginalKindDef = kindDef;
             customPawn.OriginalFactionDef = faction.def;

--- a/Source/PawnBioGenerator.cs
+++ b/Source/PawnBioGenerator.cs
@@ -1,0 +1,28 @@
+using RimWorld;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Verse;
+
+namespace EdB.PrepareCarefully {
+    // Contains an duplicate implementation of PawnBioAndNameGenerator.TryGetRandomUnusedSolidBioFor() to give us
+    // a fallback to call if other mods patch the original method in a way that makes it return false.
+    public class PawnBioGenerator {
+        public static bool TryGetRandomUnusedSolidBioFor(List<BackstoryCategoryFilter> backstoryCategories, PawnKindDef kind, Gender gender, string requiredLastName, out PawnBio result) {
+            // Pick a random category filter.
+            BackstoryCategoryFilter categoryFilter = backstoryCategories.RandomElementByWeight((c) => {
+                return c.commonality;
+            });
+            // Settle for a default category filter if none was chosen.
+            if (categoryFilter == null) {
+                categoryFilter = Reflection.PawnBioAndNameGenerator.GetFallbackCategoryGroup();
+            }
+            // Choose a weighted bio.
+            return (from bio in SolidBioDatabase.allBios.TakeRandom(20)
+                    where Reflection.PawnBioAndNameGenerator.IsBioUseable(bio, categoryFilter, kind, gender, requiredLastName)
+                    select bio).TryRandomElementByWeight(new Func<PawnBio, float>(Reflection.PawnBioAndNameGenerator.BioSelectionWeight), out result);
+        }
+    }
+}

--- a/Source/Reflection.cs
+++ b/Source/Reflection.cs
@@ -48,6 +48,11 @@ namespace EdB.PrepareCarefully {
             }
         }
         public static class PawnBioAndNameGenerator {
+            public static float BioSelectionWeight(PawnBio b) {
+                return (float)ReflectionCache.Instance.PawnBioAndNameGenerator_BioSelectionWeight.Invoke(null,
+                    new object[] { b }
+                );
+            }
             public static void FillBackstorySlotShuffled(Verse.Pawn pawn, BackstorySlot slot, ref Backstory backstory, Backstory backstoryOtherSlot, List<BackstoryCategoryFilter> backstoryCategories, FactionDef factionType) {
                 ReflectionCache.Instance.PawnBioAndNameGenerator_FillBackstorySlotShuffled.Invoke(null,
                     new object[] {
@@ -60,11 +65,22 @@ namespace EdB.PrepareCarefully {
                     new object[] { pawn, faction }
                 );
             }
+            public static bool IsBioUseable(PawnBio bio, BackstoryCategoryFilter categoryFilter, PawnKindDef kind, Gender gender, string requiredLastName) {
+                return (bool)ReflectionCache.Instance.PawnBioAndNameGenerator_IsBioUseable.Invoke(null,
+                    new object[] { bio, categoryFilter, kind, gender, requiredLastName }
+                );
+            }
             public static bool TryGetRandomUnusedSolidBioFor(List<BackstoryCategoryFilter> backstoryCategories, PawnKindDef kind, Gender gender, string requiredLastName, out PawnBio result) {
                 Object[] args = new object[] { backstoryCategories, kind, gender, requiredLastName, null };
                 bool value = (bool)ReflectionCache.Instance.PawnBioAndNameGenerator_TryGetRandomUnusedSolidBioFor.Invoke(null, args);
                 result = args[4] as PawnBio;
                 return value;
+            }
+            public static BackstoryCategoryFilter GetFallbackCategoryGroup() {
+                return (BackstoryCategoryFilter)ReflectionCache.Instance.PawnBioAndNameGenerator_FallbackCategoryGroup.GetValue(null);
+            }
+            public static List<string> GetTmpNames() {
+                return (List<string>)ReflectionCache.Instance.PawnBioAndNameGenerator_tmpNames.GetValue(null);
             }
         }
         public static class PostLoadIniter {

--- a/Source/ReflectionCache.cs
+++ b/Source/ReflectionCache.cs
@@ -14,8 +14,10 @@ namespace EdB.PrepareCarefully {
         public MethodInfo GraphicDatabaseHeadRecords_BuildDatabaseIfNecessary { get; set; }
         public MethodInfo CharacterCardUtility_WorkTagsFrom { get; set; }
         public MethodInfo GenFilePaths_FolderUnderSaveData { get; set; }
+        public MethodInfo PawnBioAndNameGenerator_BioSelectionWeight { get; set; }
         public MethodInfo PawnBioAndNameGenerator_FillBackstorySlotShuffled { get; set; }
         public MethodInfo PawnBioAndNameGenerator_GetBackstoryCategoryFiltersFor { get; set; }
+        public MethodInfo PawnBioAndNameGenerator_IsBioUseable { get; set; }
         public MethodInfo PawnBioAndNameGenerator_TryGetRandomUnusedSolidBioFor { get; set; }
         public MethodInfo PawnSkinColors_GetSkinDataIndexOfMelanin { get; set; }
         public MethodInfo ScenPart_ForcedHediff_PossibleHediffs { get; set; }
@@ -25,6 +27,8 @@ namespace EdB.PrepareCarefully {
         public FieldInfo Pawn_CachedDisabledWorkTypesPermanent { get; set; }
         public FieldInfo PostLoadIniter_SaveablesToPostLoad { get; set; }
         public FieldInfo HediffComp_GetsPermanent_PainCategory { get; set; }
+        public FieldInfo PawnBioAndNameGenerator_FallbackCategoryGroup { get; set; }
+        public FieldInfo PawnBioAndNameGenerator_tmpNames { get; set; }
 
         public static ReflectionCache Instance {
             get {
@@ -48,7 +52,8 @@ namespace EdB.PrepareCarefully {
 
             PawnBioAndNameGenerator_TryGetRandomUnusedSolidBioFor = ReflectionUtil.RequiredMethod(typeof(PawnBioAndNameGenerator), "TryGetRandomUnusedSolidBioFor",
                 new Type[] { typeof(List<BackstoryCategoryFilter>), typeof(PawnKindDef), typeof(Gender), typeof(string), typeof(PawnBio).MakeByRefType() });
-
+            PawnBioAndNameGenerator_IsBioUseable = ReflectionUtil.RequiredMethod(typeof(PawnBioAndNameGenerator), "IsBioUseable");
+            PawnBioAndNameGenerator_BioSelectionWeight = ReflectionUtil.RequiredMethod(typeof(PawnBioAndNameGenerator), "BioSelectionWeight");
 
             PawnSkinColors_GetSkinDataIndexOfMelanin = ReflectionUtil.RequiredMethod(typeof(PawnSkinColors), "GetSkinDataIndexOfMelanin", new Type[] { typeof(float) });
             ScenPart_StartingAnimal_RandomPets = ReflectionUtil.RequiredMethod(typeof(ScenPart_StartingAnimal), "RandomPets");
@@ -58,6 +63,8 @@ namespace EdB.PrepareCarefully {
             Pawn_CachedDisabledWorkTypesPermanent = ReflectionUtil.RequiredField(typeof(Pawn), "cachedDisabledWorkTypesPermanent");
             PostLoadIniter_SaveablesToPostLoad = ReflectionUtil.RequiredField(typeof(PostLoadIniter), "saveablesToPostLoad");
             HediffComp_GetsPermanent_PainCategory = ReflectionUtil.RequiredField(typeof(HediffComp_GetsPermanent), "painCategory");
+            PawnBioAndNameGenerator_FallbackCategoryGroup = ReflectionUtil.RequiredField(typeof(PawnBioAndNameGenerator), "FallbackCategoryGroup");
+            PawnBioAndNameGenerator_tmpNames = ReflectionUtil.RequiredField(typeof(PawnBioAndNameGenerator), "tmpNames");
         }
     }
 }


### PR DESCRIPTION
- Bug fixes
  - Fixed an issue when adding faction pawns from the Shattered Empire.
  - Compatibility fix with Vanilla Hair Expanded.
  - Fixed an issue with the randomize backstories button when the Alien Races mod is enabled.
- Updated the Pawn copying code to automatically copy `ThingComps` instead of explicitly copying only the comps that we know about.  This _may_ introduce problems with some mods but seems to help more than it hurts for now.