### PR TITLE
Issue #314: Temporary relations are left vulnerable to garbage collection

### DIFF
--- a/Source/Controller.cs
+++ b/Source/Controller.cs
@@ -179,9 +179,10 @@ namespace EdB.PrepareCarefully {
                 return;
             }
 
-            // Killing a pawn adds it to the world
+            // Killing a pawn adds it to the world, but we want to set the KeepForever flag
             if (pawn.Type == CustomPawnType.Temporary) {
                 if (!pawn.Pawn.Dead) {
+                    Find.WorldPawns.PassToWorld(pawn.Pawn, RimWorld.Planet.PawnDiscardDecideMode.KeepForever);
                     pawn.Pawn.Kill(null, null);
                 }
                 return;

--- a/Source/RelationshipBuilder.cs
+++ b/Source/RelationshipBuilder.cs
@@ -208,6 +208,8 @@ namespace EdB.PrepareCarefully {
                 FixedBiologicalAge = age,
                 FixedGender = gender
             }.Request));
+            // Killing a pawn will pass it to the world, but not with the KeepForever flag set, so we have to do it manually.
+            Find.WorldPawns.PassToWorld(parent.Pawn, RimWorld.Planet.PawnDiscardDecideMode.KeepForever);
             parent.Pawn.Kill(null, null);
             parent.Type = CustomPawnType.Temporary;
             return parent;


### PR DESCRIPTION
I am not absolutely sure the changes to Controller are required since
RelationshipBuilder should be adding the temporary pawns to the world
anyway (and killing them).

To consider: whether changes are needed for hidden parents (same bug
seems to occur but is a bit more complex to debug).