### PR TITLE
Refactor pawn gender assignment and relationship loading logic

### DIFF
--- a/Source/ManagerRelationships.cs
+++ b/Source/ManagerRelationships.cs
@@ -506,7 +506,7 @@ namespace EdB.PrepareCarefully {
             List<CustomizedRelationship> toDelete = new List<CustomizedRelationship>();
             foreach (var r in State.Customizations.Relationships) {
                 if (r.Source == pawn || r.Target == pawn) {
-                    deletionList.Add(r);
+                    toDelete.Add(r);
                 }
             }
             // Remove the pawn from any parent/child group that they are in.  If the parent/child
@@ -530,7 +530,7 @@ namespace EdB.PrepareCarefully {
             }
             parentChildPawns.RemoveAll((CustomizedPawn p) => { return p == pawn; });
             
-            foreach (var r in deletionList) {
+            foreach (var r in toDelete) {
                 State.Customizations.Relationships.Remove(r);
             }
 

--- a/Source/PawnLoaderV5.cs
+++ b/Source/PawnLoaderV5.cs
@@ -810,7 +810,7 @@ namespace EdB.PrepareCarefully {
                                 TitleDef = titleDef,
                                 Honor = title.favor
                             });
-                            Logger.Debug("Added title " + titleDef.defName + " for " + factionDef.defName);
+                            Logger.Debug("Added title " + (titleDef?.defName ?? "null") + " for " + factionDef.defName);
                             factions.Remove(faction);
                         }
                     }

--- a/Source/PresetLoaderV5.cs
+++ b/Source/PresetLoaderV5.cs
@@ -246,7 +246,7 @@ namespace EdB.PrepareCarefully {
                             }
                         }
                         else if (temporaryPawns.ContainsKey(id)) {
-                            group.Parents.Add(temporaryPawns[id]);
+                            group.Children.Add(temporaryPawns[id]);
                         }
                         else {
                             Logger.Warning("Could not load a custom child relationship because it could not find a pawn with the saved identifer.");

--- a/Source/PresetSaver.cs
+++ b/Source/PresetSaver.cs
@@ -40,7 +40,7 @@ namespace EdB.PrepareCarefully {
                 foreach (var pawn in state.Customizations.TemporaryPawns) {
                     preset.temporaryPawns.Add(new SaveRecordTemporaryPawnV5() {
                         id = pawn.Id,
-                        gender = pawn.Pawn?.gender.ToString()
+                        gender = pawn.Pawn != null ? pawn.Pawn.gender.ToString() : pawn.TemporaryPawn?.Gender.ToString()
                     });
                 }
                 foreach (CustomizedPawn customizedPawn in state.Customizations.AllPawns) {

--- a/Source/PresetSaver.cs
+++ b/Source/PresetSaver.cs
@@ -56,7 +56,7 @@ namespace EdB.PrepareCarefully {
                             if (!idSet.Contains(parent.Id)) {
                                 preset.temporaryPawns.Add(new SaveRecordTemporaryPawnV5() {
                                     id = parent.Id,
-                                    gender = parent.Pawn?.gender.ToString()
+                                    gender = parent.Pawn != null ? parent.Pawn.gender.ToString() : parent.TemporaryPawn?.Gender.ToString()
                                 });
                                 idSet.Add(parent.Id);
                             }

--- a/Source/PresetSaver.cs
+++ b/Source/PresetSaver.cs
@@ -67,7 +67,7 @@ namespace EdB.PrepareCarefully {
                             if (!idSet.Contains(child.Id)) {
                                 preset.temporaryPawns.Add(new SaveRecordTemporaryPawnV5() {
                                     id = child.Id,
-                                    gender = child.Pawn?.gender.ToString()
+                                    gender = child.Pawn != null ? child.Pawn.gender.ToString() : child.TemporaryPawn?.Gender.ToString()
                                 });
                                 idSet.Add(child.Id);
                             }


### PR DESCRIPTION
Refactor the deletion logic to improve relationship removals and ensure proper handling of null values in pawn gender assignments. Fix relationship loading by correctly adding temporary pawns as children.